### PR TITLE
Don't forget to remove scheduled event data when notification channel is not set

### DIFF
--- a/src/Services/Update/ScheduledEventUpdateService.cs
+++ b/src/Services/Update/ScheduledEventUpdateService.cs
@@ -317,6 +317,12 @@ public sealed class ScheduledEventUpdateService : BackgroundService
     private async Task<Result> SendScheduledEventCompletedMessage(ScheduledEventData eventData, GuildData data,
         CancellationToken ct)
     {
+        if (GuildSettings.EventNotificationChannel.Get(data.Settings).Empty())
+        {
+            data.ScheduledEvents.Remove(eventData.Id);
+            return Result.FromSuccess();
+        }
+
         var completedEmbed = new EmbedBuilder().WithTitle(string.Format(Messages.EventCompleted, eventData.Name))
             .WithDescription(
                 string.Format(
@@ -349,6 +355,7 @@ public sealed class ScheduledEventUpdateService : BackgroundService
     {
         if (GuildSettings.EventNotificationChannel.Get(data.Settings).Empty())
         {
+            data.ScheduledEvents.Remove(eventData.Id);
             return Result.FromSuccess();
         }
 


### PR DESCRIPTION
This PR fixes an issue that caused data of completed/cancelled scheduled events to never be collected if EventNotificationChannel wasn't set