### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ obj/
 riderModule.iml
 /_ReSharper.Caches/
 /.vs/
+GuildData/
+Logs/


### PR DESCRIPTION
In this PR I added `GuildData/` and `Logs/` to `.gitignore`. When Octobot starts, it creates `GuildData/` and `Logs/` in active directory from where you ran bot. So if you try to run Octobot outside of `bin/` but inside project's folder, `.gitignore` will not ignore those files.