### PR TITLE
Correct illegal nickname characters regex

### DIFF
--- a/src/Services/Update/MemberUpdateService.cs
+++ b/src/Services/Update/MemberUpdateService.cs
@@ -197,7 +197,7 @@ public sealed partial class MemberUpdateService : BackgroundService
             ct: ct);
     }
 
-    [GeneratedRegex("[^0-9A-zЁА-яё]")]
+    [GeneratedRegex("[^0-9A-Za-zА-Яа-яЁё]")]
     private static partial Regex IllegalChars();
 
     private async Task<Result> TickReminderAsync(Reminder reminder, IUser user, MemberData data, CancellationToken ct)


### PR DESCRIPTION
Apparently there are non-letter characters in between A-Z and a-z