### PR TITLE
Correct issue label names per recent changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Create a report to help us improve
-labels: [ "bug" ]
+labels: [ "type: bug" ]
 body:
     - type: markdown
       attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Create a request for a feature you would like
-labels: [ "type: enhancement" ]
+labels: [ "type: feature" ]
 body:
     - type: textarea
       id: background

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,8 @@ updates:
       # Allow both direct and indirect updates for all packages
       - dependency-type: "all"
     labels:
-      - "type: dependencies"
+      - "type: change"
+      - "area: build/ci"
 
   - package-ecosystem: "nuget" # See documentation for possible values
     directory: "/" # Location of package manifests
@@ -23,4 +24,5 @@ updates:
       # Allow both direct and indirect updates for all packages
       - dependency-type: "all"
     labels:
-      - "type: dependencies"
+      - "type: change"
+      - "area: build/ci"


### PR DESCRIPTION
Issue labels have been reworked recently, causing some files in `.github` to reference non-existing issue labels. This PR updates the names of labels in these files.