### PR TITLE
Sanitize input text in message edit log

### DIFF
--- a/src/Extensions/DiffPaneModelExtensions.cs
+++ b/src/Extensions/DiffPaneModelExtensions.cs
@@ -12,17 +12,17 @@ public static class DiffPaneModelExtensions
         {
             if (line.Type is ChangeType.Deleted)
             {
-                builder.Append("- ");
+                builder.Append("-- ");
             }
 
             if (line.Type is ChangeType.Inserted)
             {
-                builder.Append("+ ");
+                builder.Append("++ ");
             }
 
             if (line.Type is not ChangeType.Imaginary)
             {
-                builder.AppendLine(line.Text);
+                builder.AppendLine(line.Text.SanitizeForDiffBlock());
             }
         }
 

--- a/src/Extensions/StringExtensions.cs
+++ b/src/Extensions/StringExtensions.cs
@@ -17,6 +17,18 @@ public static class StringExtensions
     }
 
     /// <summary>
+    ///     Sanitizes a string for use in <see cref="Markdown.BlockCode(string, string)" /> when "language" is "diff" by
+    ///     prepending a zero-width space before syntax highlighting characters (+ and -).
+    /// </summary>
+    /// <remarks>This does not call <see cref="SanitizeForBlockCode"/>, you have to do so yourself if needed.</remarks>
+    /// <param name="s">The string to sanitize.</param>
+    /// <returns>The sanitized string that can be safely used in <see cref="Markdown.BlockCode(string, string)" /> with "diff" as the language.</returns>
+    public static string SanitizeForDiffBlock(this string s)
+    {
+        return $"​{s}";
+    }
+
+    /// <summary>
     ///     Sanitizes a string (see <see cref="SanitizeForBlockCode" />) and formats the string to use Markdown Block Code
     ///     formatting with a specified
     ///     language for syntax highlighting.

--- a/src/Extensions/StringExtensions.cs
+++ b/src/Extensions/StringExtensions.cs
@@ -20,7 +20,7 @@ public static class StringExtensions
 
     /// <summary>
     ///     Sanitizes a string for use in <see cref="Markdown.BlockCode(string, string)" /> when "language" is "diff" by
-    ///     prepending a zero-width space before syntax highlighting characters (+ and -).
+    ///     prepending a zero-width space before the input string to prevent Discord from applying syntax highlighting.
     /// </summary>
     /// <remarks>This does not call <see cref="SanitizeForBlockCode"/>, you have to do so yourself if needed.</remarks>
     /// <param name="s">The string to sanitize.</param>

--- a/src/Extensions/StringExtensions.cs
+++ b/src/Extensions/StringExtensions.cs
@@ -5,6 +5,8 @@ namespace Octobot.Extensions;
 
 public static class StringExtensions
 {
+    private const string ZeroWidthSpace = "​";
+
     /// <summary>
     ///     Sanitizes a string for use in <see cref="Markdown.BlockCode(string)" /> by inserting zero-width spaces in between
     ///     symbols used to format the string with block code.
@@ -13,7 +15,7 @@ public static class StringExtensions
     /// <returns>The sanitized string that can be safely used in <see cref="Markdown.BlockCode(string)" />.</returns>
     private static string SanitizeForBlockCode(this string s)
     {
-        return s.Replace("```", "​`​`​`​");
+        return s.Replace("```", $"{ZeroWidthSpace}`{ZeroWidthSpace}`{ZeroWidthSpace}`{ZeroWidthSpace}");
     }
 
     /// <summary>
@@ -25,7 +27,7 @@ public static class StringExtensions
     /// <returns>The sanitized string that can be safely used in <see cref="Markdown.BlockCode(string, string)" /> with "diff" as the language.</returns>
     public static string SanitizeForDiffBlock(this string s)
     {
-        return $"​{s}";
+        return $"{ZeroWidthSpace}{s}";
     }
 
     /// <summary>


### PR DESCRIPTION
This PR fixes an issue that caused syntax highlighting to be applied to incorrect lines in the message edit log. The fix is to prepend a zero-width space before every line of input text. This prevents Discord from highlighting the line when it wasn't edited