### PR TITLE
Use MemberData to determine a subscriber's role list

### DIFF
--- a/src/Services/Update/ScheduledEventUpdateService.cs
+++ b/src/Services/Update/ScheduledEventUpdateService.cs
@@ -286,7 +286,7 @@ public sealed class ScheduledEventUpdateService : BackgroundService
         };
 
         var contentResult = await _utility.GetEventNotificationMentions(
-            scheduledEvent, data.Settings, ct);
+            scheduledEvent, data, ct);
         if (!contentResult.IsDefined(out var content))
         {
             return Result.FromError(contentResult);
@@ -412,7 +412,7 @@ public sealed class ScheduledEventUpdateService : BackgroundService
         IGuildScheduledEvent scheduledEvent, GuildData data, CancellationToken ct)
     {
         var contentResult = await _utility.GetEventNotificationMentions(
-            scheduledEvent, data.Settings, ct);
+            scheduledEvent, data, ct);
         if (!contentResult.IsDefined(out var content))
         {
             return Result.FromError(contentResult);


### PR DESCRIPTION
Closes #163 

Discord's API sucks a lot. You ask it for a member, but it won't give you a member. This is why this PR updates the `GetEventNotificationMentions` method used to determine what roles and users should get pinged for a scheduled event. Previously, the bot asked Discord to provide the member for each subscriber to determine whether or not they have the event notification role (to avoid pinging people personally when the role would already ping them). With this pull request, the bot uses MemberData, it's own member storage, for that purpose (if you're wondering why, refer to the first two sentences)