### PR TITLE
Fix Reminder serialization/deserialization

### DIFF
--- a/src/Data/MemberData.cs
+++ b/src/Data/MemberData.cs
@@ -5,10 +5,14 @@ namespace Octobot.Data;
 /// </summary>
 public sealed class MemberData
 {
-    public MemberData(ulong id, DateTimeOffset? bannedUntil = null)
+    public MemberData(ulong id, DateTimeOffset? bannedUntil = null, List<Reminder>? reminders = null)
     {
         Id = id;
         BannedUntil = bannedUntil;
+        if (reminders is not null)
+        {
+            Reminders = reminders;
+        }
     }
 
     public ulong Id { get; }

--- a/src/Data/Reminder.cs
+++ b/src/Data/Reminder.cs
@@ -2,7 +2,7 @@ namespace Octobot.Data;
 
 public struct Reminder
 {
-    public DateTimeOffset At;
-    public string Text;
-    public ulong Channel;
+    public DateTimeOffset At { get; init; }
+    public string Text { get; init; }
+    public ulong Channel { get; init; }
 }


### PR DESCRIPTION
Closes #124 

Before we dive into this PR, let's explain a few rules of serialization and deserialization in System.Text.Json (often referred as STJ).

The important rule of serialization is that fields are ***not*** serialized unless the serializer gets passed an instance of `JsonSerializerOptions` that explicitly tells it to include fields. However, properties are serialized by default.

The important rule of ***de***serialization is that class members are only deserialized if:
1) In case of properties, they must have a setter
2) If they do not have a setter, the constructor must have an argument, required or optional, that will act as the setter for that property.

Unfortunately, both of these rules were ignored in some commit that refactored reminders. This PR is here to fix that issue by:
1) Converting fields in `Reminder.cs` to properties
2) Adding an optional argument to the `MemberData` constructor