### PR TITLE
Unschedule scheduled event status update only if last update was successful

### DIFF
--- a/src/Services/Update/ScheduledEventUpdateService.cs
+++ b/src/Services/Update/ScheduledEventUpdateService.cs
@@ -114,7 +114,11 @@ public sealed class ScheduledEventUpdateService : BackgroundService
             var eventData = data.ScheduledEvents[@event.ID.Value];
             eventData.Name = @event.Name;
             eventData.ScheduledStartTime = @event.ScheduledStartTime;
-            eventData.ScheduleOnStatusUpdated = eventData.Status != @event.Status;
+            if (!eventData.ScheduleOnStatusUpdated)
+            {
+                eventData.ScheduleOnStatusUpdated = eventData.Status != @event.Status;
+            }
+
             eventData.Status = @event.Status;
         }
     }
@@ -297,7 +301,8 @@ public sealed class ScheduledEventUpdateService : BackgroundService
             return Result.FromError(embedDescriptionResult);
         }
 
-        var startedEmbed = new EmbedBuilder().WithTitle(string.Format(Messages.EventStarted, Markdown.Sanitize(scheduledEvent.Name)))
+        var startedEmbed = new EmbedBuilder()
+            .WithTitle(string.Format(Messages.EventStarted, Markdown.Sanitize(scheduledEvent.Name)))
             .WithDescription(embedDescription)
             .WithColour(ColorsList.Green)
             .WithCurrentTimestamp()
@@ -322,7 +327,8 @@ public sealed class ScheduledEventUpdateService : BackgroundService
             return Result.FromSuccess();
         }
 
-        var completedEmbed = new EmbedBuilder().WithTitle(string.Format(Messages.EventCompleted, Markdown.Sanitize(eventData.Name)))
+        var completedEmbed = new EmbedBuilder()
+            .WithTitle(string.Format(Messages.EventCompleted, Markdown.Sanitize(eventData.Name)))
             .WithDescription(
                 string.Format(
                     Messages.EventDuration,


### PR DESCRIPTION
This PR fixes an issue that prevented scheduled event status updates from running again if they failed. This happened because, before each update, the events would be synchronized. The `ScheduleOnStatusUpdated` field would be set even if it's already `true`, which will cause it to be set to `false` for unsuccessful updates. The issue is fixed by surrounding the field set call with a condition that will prevent setting the field from `true` to `false`