### PR TITLE
Add filtering by message author to /clear

### DIFF
--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -564,4 +564,10 @@
   <data name="GuildInfoBoostCount" xml:space="preserve">
       <value>Boost count</value>
   </data>
+  <data name="NoMessagesToClear" xml:space="preserve">
+      <value>There are no messages matching your filter!</value>
+  </data>
+  <data name="MessagesClearedFiltered" xml:space="preserve">
+      <value>Cleared {0} messages from {1}</value>
+  </data>
 </root>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -564,4 +564,10 @@
   <data name="GuildInfoBoostCount" xml:space="preserve">
       <value>Количество бустов</value>
   </data>
+  <data name="NoMessagesToClear" xml:space="preserve">
+      <value>Нет сообщений, которые подходят под твой фильтр!</value>
+  </data>
+  <data name="MessagesClearedFiltered" xml:space="preserve">
+      <value>Очищено {0} сообщений от {1}</value>
+  </data>
 </root>

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -564,4 +564,10 @@
   <data name="GuildInfoBoostCount" xml:space="preserve">
       <value>кол-во бустов</value>
   </data>
+  <data name="NoMessagesToClear" xml:space="preserve">
+      <value>алло а чё мне удалять-то</value>
+  </data>
+  <data name="MessagesClearedFiltered" xml:space="preserve">
+      <value>вырезано {0} забавных сообщений от {1}</value>
+  </data>
 </root>

--- a/src/Messages.Designer.cs
+++ b/src/Messages.Designer.cs
@@ -980,5 +980,21 @@ namespace Octobot {
                 return ResourceManager.GetString("GuildInfoBoostCount", resourceCulture);
             }
         }
+
+        internal static string NoMessagesToClear
+        {
+            get
+            {
+                return ResourceManager.GetString("NoMessagesToClear", resourceCulture);
+            }
+        }
+
+        internal static string MessagesClearedFiltered
+        {
+            get
+            {
+                return ResourceManager.GetString("MessagesClearedFiltered", resourceCulture);
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #164 

This PR adds an optional argument to `/clear` - `author` of type User.

If the user is specified, only messages sent by that user will be cleared. Simple as that.