### PR TITLE
Handle guild data load errors better

### DIFF
--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -570,4 +570,10 @@
   <data name="MessagesClearedFiltered" xml:space="preserve">
       <value>Cleared {0} messages from {1}</value>
   </data>
+  <data name="DataLoadFailedTitle" xml:space="preserve">
+      <value>An error occurred during guild data load.</value>
+  </data>
+  <data name="DataLoadFailedDescription" xml:space="preserve">
+      <value>This will lead to unexpected behavior. Data will no longer be saved</value>
+  </data>
 </root>

--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -576,4 +576,7 @@
   <data name="DataLoadFailedDescription" xml:space="preserve">
       <value>This will lead to unexpected behavior. Data will no longer be saved</value>
   </data>
+  <data name="ContactDevelopers" xml:space="preserve">
+      <value>Contact the developers if the problem occurs again.</value>
+  </data>
 </root>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -576,4 +576,7 @@
   <data name="DataLoadFailedDescription" xml:space="preserve">
       <value>Это может привести к неожиданному поведению. Данные больше не будут сохраняться.</value>
   </data>
+  <data name="ContactDevelopers" xml:space="preserve">
+      <value>Обратись к разработчикам, если проблема возникнет снова.</value>
+  </data>
 </root>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -570,4 +570,10 @@
   <data name="MessagesClearedFiltered" xml:space="preserve">
       <value>Очищено {0} сообщений от {1}</value>
   </data>
+  <data name="DataLoadFailedTitle" xml:space="preserve">
+      <value>Произошла ошибка при загрузке данных сервера.</value>
+  </data>
+  <data name="DataLoadFailedDescription" xml:space="preserve">
+      <value>Это может привести к неожиданному поведению. Данные больше не будут сохраняться.</value>
+  </data>
 </root>

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -576,4 +576,7 @@
   <data name="DataLoadFailedDescription" xml:space="preserve">
       <value>возможно всё съедет с крыши, но знай, что я больше ничё не сохраню.</value>
   </data>
+  <data name="ContactDevelopers" xml:space="preserve">
+      <value>если ты это читаешь второй раз за сегодня, пиши разрабам</value>
+  </data>
 </root>

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -571,7 +571,7 @@
       <value>вырезано {0} забавных сообщений от {1}</value>
   </data>
   <data name="DataLoadFailedTitle" xml:space="preserve">
-      <value>произошёл пиздец в гилддате.</value>
+      <value>произошёл тотальный разнос в гилддате.</value>
   </data>
   <data name="DataLoadFailedDescription" xml:space="preserve">
       <value>возможно всё съедет с крыши, но знай, что я больше ничё не сохраню.</value>

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -570,4 +570,10 @@
   <data name="MessagesClearedFiltered" xml:space="preserve">
       <value>вырезано {0} забавных сообщений от {1}</value>
   </data>
+  <data name="DataLoadFailedTitle" xml:space="preserve">
+      <value>произошёл пиздец в гилддате.</value>
+  </data>
+  <data name="DataLoadFailedDescription" xml:space="preserve">
+      <value>возможно всё съедет с крыши, но знай, что я больше ничё не сохраню.</value>
+  </data>
 </root>

--- a/src/Data/GuildData.cs
+++ b/src/Data/GuildData.cs
@@ -17,10 +17,12 @@ public sealed class GuildData
     public readonly JsonNode Settings;
     public readonly string SettingsPath;
 
+    public readonly bool DataLoadFailed;
+
     public GuildData(
         JsonNode settings, string settingsPath,
         Dictionary<ulong, ScheduledEventData> scheduledEvents, string scheduledEventsPath,
-        Dictionary<ulong, MemberData> memberData, string memberDataPath)
+        Dictionary<ulong, MemberData> memberData, string memberDataPath, bool dataLoadFailed)
     {
         Settings = settings;
         SettingsPath = settingsPath;
@@ -28,6 +30,7 @@ public sealed class GuildData
         ScheduledEventsPath = scheduledEventsPath;
         MemberData = memberData;
         MemberDataPath = memberDataPath;
+        DataLoadFailed = dataLoadFailed;
     }
 
     public MemberData GetOrCreateMemberData(Snowflake memberId)

--- a/src/Messages.Designer.cs
+++ b/src/Messages.Designer.cs
@@ -996,5 +996,21 @@ namespace Octobot {
                 return ResourceManager.GetString("MessagesClearedFiltered", resourceCulture);
             }
         }
+
+        internal static string DataLoadFailedTitle
+        {
+            get
+            {
+                return ResourceManager.GetString("DataLoadFailedTitle", resourceCulture);
+            }
+        }
+
+        internal static string DataLoadFailedDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("DataLoadFailedDescription", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Messages.Designer.cs
+++ b/src/Messages.Designer.cs
@@ -1012,5 +1012,12 @@ namespace Octobot {
                 return ResourceManager.GetString("DataLoadFailedDescription", resourceCulture);
             }
         }
+        internal static string ContactDevelopers
+        {
+            get
+            {
+                return ResourceManager.GetString("ContactDevelopers", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Responders/GuildLoadedResponder.cs
+++ b/src/Responders/GuildLoadedResponder.cs
@@ -62,6 +62,7 @@ public class GuildLoadedResponder : IResponder<IGuildCreate>
             var errorEmbed = new EmbedBuilder()
                 .WithSmallTitle(Messages.DataLoadFailedTitle, bot)
                 .WithDescription(Messages.DataLoadFailedDescription)
+                .WithFooter(Messages.ContactDevelopers)
                 .WithColour(ColorsList.Red)
                 .Build();
 

--- a/src/Responders/GuildUnloadedResponder.cs
+++ b/src/Responders/GuildUnloadedResponder.cs
@@ -30,7 +30,7 @@ public class GuildUnloadedResponder : IResponder<IGuildDelete>
         var isDataRemoved = _guildData.UnloadGuildData(guildId);
         if (isDataRemoved)
         {
-            _logger.LogInformation("Left guild {GuildId}", guildId);
+            _logger.LogInformation("Unloaded guild {GuildId}", guildId);
         }
 
         return Task.FromResult(Result.FromSuccess());


### PR DESCRIPTION
Previously, any errors in guild data load will cause the bot to be unusable in that guild. It didn't help that the end users had no information that something was wrong! Now, any errors will be logged better (with the full path to the file that couldn't be loaded), and the users will receive a message saying that functionality is degraded

The old way to save objects was to serialize them directly into streams opened by `File#Create`. This can cause problems if the serialization isn't completed, because `File#Create` overwrites the file with an empty one on the spot. Now, objects are first deserialized into a temporary file, then the original is replaced by the temporary, then the temporary is deleted.

Errors during guild data load would sometimes cause the bot to replace the corrupted file with a default one whenever a save is triggered. Now, guilds with load errors won't have their data saved to aid in debugging