### PR TITLE
Add more info output to /delremind

### DIFF
--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -478,7 +478,7 @@
       <value>Position in list: {0}</value>
   </data>
   <data name="ReminderTime" xml:space="preserve">
-      <value>Reminder sending time: {0}</value>
+      <value>Reminder send time: {0}</value>
   </data>
   <data name="ReminderText" xml:space="preserve">
     <value>Reminder text: {0}</value>

--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -570,7 +570,4 @@
   <data name="MessagesClearedFiltered" xml:space="preserve">
       <value>Cleared {0} messages from {1}</value>
   </data>
-  <data name="ReminderSelectedPosition" xml:space="preserve">
-      <value>Selected position in list: {0}</value>
-  </data>
 </root>

--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -570,4 +570,7 @@
   <data name="MessagesClearedFiltered" xml:space="preserve">
       <value>Cleared {0} messages from {1}</value>
   </data>
+  <data name="ReminderSelectedPosition" xml:space="preserve">
+      <value>Selected position in list: {0}</value>
+  </data>
 </root>

--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -477,8 +477,8 @@
   <data name="ReminderPosition" xml:space="preserve">
       <value>Position in list: {0}</value>
   </data>
-  <data name="ReminderWillBeSentOn" xml:space="preserve">
-    <value>The reminder will be sent on: {0}</value>
+  <data name="ReminderTime" xml:space="preserve">
+      <value>Reminder sending time: {0}</value>
   </data>
   <data name="ReminderText" xml:space="preserve">
     <value>Reminder text: {0}</value>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -570,7 +570,4 @@
   <data name="MessagesClearedFiltered" xml:space="preserve">
       <value>Очищено {0} сообщений от {1}</value>
   </data>
-  <data name="ReminderSelectedPosition" xml:space="preserve">
-      <value>Выбранная позиция в списке: {0}</value>
-  </data>
 </root>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -477,8 +477,8 @@
   <data name="ReminderPosition" xml:space="preserve">
       <value>Позиция в списке: {0}</value>
   </data>
-  <data name="ReminderWillBeSentOn" xml:space="preserve">
-    <value>Напоминание будет отправлено: {0}</value>
+  <data name="ReminderTime" xml:space="preserve">
+      <value>Время отправления напоминания: {0}</value>
   </data>
   <data name="ReminderText" xml:space="preserve">
     <value>Текст напоминания: {0}</value>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -570,4 +570,7 @@
   <data name="MessagesClearedFiltered" xml:space="preserve">
       <value>Очищено {0} сообщений от {1}</value>
   </data>
+  <data name="ReminderSelectedPosition" xml:space="preserve">
+      <value>Выбранная позиция в списке: {0}</value>
+  </data>
 </root>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -478,7 +478,7 @@
       <value>Позиция в списке: {0}</value>
   </data>
   <data name="ReminderTime" xml:space="preserve">
-      <value>Время отправления напоминания: {0}</value>
+      <value>Время отправки напоминания: {0}</value>
   </data>
   <data name="ReminderText" xml:space="preserve">
     <value>Текст напоминания: {0}</value>

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -477,8 +477,8 @@
   <data name="ReminderPosition" xml:space="preserve">
       <value>номер в списке: {0}</value>
   </data>
-  <data name="ReminderWillBeSentOn" xml:space="preserve">
-    <value>я пну тебе это: {0}</value>
+  <data name="ReminderTime" xml:space="preserve">
+      <value>время отправки: {0}</value>
   </data>
   <data name="ReminderText" xml:space="preserve">
     <value>че там в напоминалке: {0}</value>

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -570,4 +570,7 @@
   <data name="MessagesClearedFiltered" xml:space="preserve">
       <value>вырезано {0} забавных сообщений от {1}</value>
   </data>
+  <data name="ReminderSelectedPosition" xml:space="preserve">
+      <value>селекнутый номер в списке: {0}</value>
+  </data>
 </root>

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -570,7 +570,4 @@
   <data name="MessagesClearedFiltered" xml:space="preserve">
       <value>вырезано {0} забавных сообщений от {1}</value>
   </data>
-  <data name="ReminderSelectedPosition" xml:space="preserve">
-      <value>селекнутый номер в списке: {0}</value>
-  </data>
 </root>

--- a/src/Commands/RemindCommandGroup.cs
+++ b/src/Commands/RemindCommandGroup.cs
@@ -195,14 +195,12 @@ public class RemindCommandGroup : CommandGroup
         var data = await _guildData.GetData(guildId, CancellationToken);
         Messages.Culture = GuildSettings.Language.Get(data.Settings);
 
-        return await DeleteReminderAsync(data.GetOrCreateMemberData(executorId), position, bot, CancellationToken);
+        return await DeleteReminderAsync(data.GetOrCreateMemberData(executorId), position - 1, bot, CancellationToken);
     }
 
-    private async Task<Result> DeleteReminderAsync(MemberData data, int position, IUser bot,
+    private async Task<Result> DeleteReminderAsync(MemberData data, int index, IUser bot,
         CancellationToken ct)
     {
-        var index = position - 1;
-
         if (index >= data.Reminders.Count)
         {
             var failedEmbed = new EmbedBuilder().WithSmallTitle(Messages.InvalidReminderPosition, bot)
@@ -212,14 +210,9 @@ public class RemindCommandGroup : CommandGroup
             return await _feedback.SendContextualEmbedResultAsync(failedEmbed, ct);
         }
 
-        var description = new StringBuilder()
-            .Append("- ").AppendLine(string.Format(Messages.ReminderSelectedPosition, Markdown.InlineCode(position.ToString())))
-            .Append("- ").AppendLine(string.Format(Messages.ReminderText, Markdown.InlineCode(data.Reminders[index].Text)));
-
         data.Reminders.RemoveAt(index);
 
         var embed = new EmbedBuilder().WithSmallTitle(Messages.ReminderDeleted, bot)
-            .WithDescription(description.ToString())
             .WithColour(ColorsList.Green)
             .Build();
 

--- a/src/Commands/RemindCommandGroup.cs
+++ b/src/Commands/RemindCommandGroup.cs
@@ -195,12 +195,14 @@ public class RemindCommandGroup : CommandGroup
         var data = await _guildData.GetData(guildId, CancellationToken);
         Messages.Culture = GuildSettings.Language.Get(data.Settings);
 
-        return await DeleteReminderAsync(data.GetOrCreateMemberData(executorId), position - 1, bot, CancellationToken);
+        return await DeleteReminderAsync(data.GetOrCreateMemberData(executorId), position, bot, CancellationToken);
     }
 
-    private async Task<Result> DeleteReminderAsync(MemberData data, int index, IUser bot,
+    private async Task<Result> DeleteReminderAsync(MemberData data, int position, IUser bot,
         CancellationToken ct)
     {
+        var index = position - 1;
+
         if (index >= data.Reminders.Count)
         {
             var failedEmbed = new EmbedBuilder().WithSmallTitle(Messages.InvalidReminderPosition, bot)
@@ -210,9 +212,14 @@ public class RemindCommandGroup : CommandGroup
             return await _feedback.SendContextualEmbedResultAsync(failedEmbed, ct);
         }
 
+        var description = new StringBuilder()
+            .Append("- ").AppendLine(string.Format(Messages.ReminderSelectedPosition, Markdown.InlineCode(position.ToString())))
+            .Append("- ").AppendLine(string.Format(Messages.ReminderText, Markdown.InlineCode(data.Reminders[index].Text)));
+
         data.Reminders.RemoveAt(index);
 
         var embed = new EmbedBuilder().WithSmallTitle(Messages.ReminderDeleted, bot)
+            .WithDescription(description.ToString())
             .WithColour(ColorsList.Green)
             .Build();
 

--- a/src/Commands/RemindCommandGroup.cs
+++ b/src/Commands/RemindCommandGroup.cs
@@ -92,7 +92,7 @@ public class RemindCommandGroup : CommandGroup
             builder.Append("- ").AppendLine(string.Format(Messages.ReminderPosition, Markdown.InlineCode((i + 1).ToString())))
                 .Append(" - ").AppendLine(string.Format(Messages.ReminderText, Markdown.InlineCode(reminder.Text)))
                 .Append(" - ")
-                .AppendLine(string.Format(Messages.ReminderWillBeSentOn, Markdown.Timestamp(reminder.At)));
+                .AppendLine(string.Format(Messages.ReminderTime, Markdown.Timestamp(reminder.At)));
         }
 
         var embed = new EmbedBuilder().WithSmallTitle(
@@ -155,7 +155,7 @@ public class RemindCommandGroup : CommandGroup
 
         var builder = new StringBuilder().Append("- ").AppendLine(string.Format(
                 Messages.ReminderText, Markdown.InlineCode(text)))
-            .Append("- ").Append(string.Format(Messages.ReminderWillBeSentOn, Markdown.Timestamp(remindAt)));
+            .Append("- ").Append(string.Format(Messages.ReminderTime, Markdown.Timestamp(remindAt)));
 
         var embed = new EmbedBuilder().WithSmallTitle(
                 string.Format(Messages.ReminderCreated, executor.GetTag()), executor)
@@ -210,9 +210,16 @@ public class RemindCommandGroup : CommandGroup
             return await _feedback.SendContextualEmbedResultAsync(failedEmbed, ct);
         }
 
+        var reminder = data.Reminders[index];
+
+        var description = new StringBuilder()
+            .Append("- ").AppendLine(string.Format(Messages.ReminderText, Markdown.InlineCode(reminder.Text)))
+            .Append("- ").AppendLine(string.Format(Messages.ReminderTime, Markdown.Timestamp(reminder.At)));
+
         data.Reminders.RemoveAt(index);
 
         var embed = new EmbedBuilder().WithSmallTitle(Messages.ReminderDeleted, bot)
+            .WithDescription(description.ToString())
             .WithColour(ColorsList.Green)
             .Build();
 

--- a/src/Messages.Designer.cs
+++ b/src/Messages.Designer.cs
@@ -786,9 +786,9 @@ namespace Octobot {
             }
         }
 
-        internal static string ReminderWillBeSentOn {
+        internal static string ReminderTime {
             get {
-                return ResourceManager.GetString("ReminderWillBeSentOn", resourceCulture);
+                return ResourceManager.GetString("ReminderTime", resourceCulture);
             }
         }
 

--- a/src/Messages.Designer.cs
+++ b/src/Messages.Designer.cs
@@ -996,5 +996,13 @@ namespace Octobot {
                 return ResourceManager.GetString("MessagesClearedFiltered", resourceCulture);
             }
         }
+
+        internal static string ReminderSelectedPosition
+        {
+            get
+            {
+                return ResourceManager.GetString("ReminderSelectedPosition", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Messages.Designer.cs
+++ b/src/Messages.Designer.cs
@@ -996,13 +996,5 @@ namespace Octobot {
                 return ResourceManager.GetString("MessagesClearedFiltered", resourceCulture);
             }
         }
-
-        internal static string ReminderSelectedPosition
-        {
-            get
-            {
-                return ResourceManager.GetString("ReminderSelectedPosition", resourceCulture);
-            }
-        }
     }
 }


### PR DESCRIPTION
_There are times when you want to be sure of what you've destroyed._

Therefore, in this PR I added the output of the text of the deleted reminder along with its position in the list, because you can make a mistake with deleting a reminder and forget about what you needed to be reminded about.