### PR TITLE
Limit string argument length to avoid "embed description too long" errors

### DIFF
--- a/src/Commands/BanCommandGroup.cs
+++ b/src/Commands/BanCommandGroup.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Text;
 using JetBrains.Annotations;
 using Octobot.Data;
@@ -72,7 +73,8 @@ public class BanCommandGroup : CommandGroup
     [UsedImplicitly]
     public async Task<Result> ExecuteBanAsync(
         [Description("User to ban")] IUser target,
-        [Description("Ban reason")] string reason,
+        [Description("Ban reason")] [MaxLength(256)]
+        string reason,
         [Description("Ban duration")] TimeSpan? duration = null)
     {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out var executorId))
@@ -216,7 +218,8 @@ public class BanCommandGroup : CommandGroup
     [UsedImplicitly]
     public async Task<Result> ExecuteUnban(
         [Description("User to unban")] IUser target,
-        [Description("Unban reason")] string reason)
+        [Description("Unban reason")] [MaxLength(256)]
+        string reason)
     {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out var executorId))
         {

--- a/src/Commands/KickCommandGroup.cs
+++ b/src/Commands/KickCommandGroup.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using JetBrains.Annotations;
 using Octobot.Data;
 using Octobot.Extensions;
@@ -67,7 +68,8 @@ public class KickCommandGroup : CommandGroup
     [UsedImplicitly]
     public async Task<Result> ExecuteKick(
         [Description("Member to kick")] IUser target,
-        [Description("Kick reason")] string reason)
+        [Description("Kick reason")] [MaxLength(256)]
+        string reason)
     {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out var executorId))
         {

--- a/src/Commands/MuteCommandGroup.cs
+++ b/src/Commands/MuteCommandGroup.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Text;
 using JetBrains.Annotations;
 using Octobot.Data;
@@ -69,7 +70,8 @@ public class MuteCommandGroup : CommandGroup
     [UsedImplicitly]
     public async Task<Result> ExecuteMute(
         [Description("Member to mute")] IUser target,
-        [Description("Mute reason")] string reason,
+        [Description("Mute reason")] [MaxLength(256)]
+        string reason,
         [Description("Mute duration")] TimeSpan duration)
     {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out var executorId))
@@ -233,7 +235,8 @@ public class MuteCommandGroup : CommandGroup
     [UsedImplicitly]
     public async Task<Result> ExecuteUnmute(
         [Description("Member to unmute")] IUser target,
-        [Description("Unmute reason")] string reason)
+        [Description("Unmute reason")] [MaxLength(256)]
+        string reason)
     {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out var executorId))
         {

--- a/src/Commands/RemindCommandGroup.cs
+++ b/src/Commands/RemindCommandGroup.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Text;
 using JetBrains.Annotations;
 using Octobot.Data;
@@ -119,7 +120,8 @@ public class RemindCommandGroup : CommandGroup
     public async Task<Result> ExecuteReminderAsync(
         [Description("After what period of time mention the reminder")]
         TimeSpan @in,
-        [Description("Reminder text")] string text)
+        [Description("Reminder text")] [MaxLength(512)]
+        string text)
     {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out var executorId))
         {

--- a/src/Commands/SettingsCommandGroup.cs
+++ b/src/Commands/SettingsCommandGroup.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Text;
 using System.Text.Json.Nodes;
 using JetBrains.Annotations;
@@ -167,7 +168,8 @@ public class SettingsCommandGroup : CommandGroup
     public async Task<Result> ExecuteEditSettingsAsync(
         [Description("The setting whose value you want to change")]
         AllOptionsEnum setting,
-        [Description("Setting value")] string value)
+        [Description("Setting value")] [MaxLength(512)]
+        string value)
     {
         if (!_context.TryGetContextIDs(out var guildId, out var channelId, out var executorId))
         {


### PR DESCRIPTION
This PR fixes an error that would appear if a string that's way too long was passed as a command argument by limiting the string's length
![image](https://github.com/LabsDevelopment/Octobot/assets/61277953/8f8267fd-d382-4a24-b92d-5f9966d7563b)
