### PR TITLE
Use IFeedbackService interface instead of implementation

### DIFF
--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -32,14 +32,14 @@ public class AboutCommandGroup : CommandGroup
     };
 
     private readonly ICommandContext _context;
-    private readonly FeedbackService _feedback;
+    private readonly IFeedbackService _feedback;
     private readonly GuildDataService _guildData;
     private readonly IDiscordRestUserAPI _userApi;
     private readonly IDiscordRestGuildAPI _guildApi;
 
     public AboutCommandGroup(
         ICommandContext context, GuildDataService guildData,
-        FeedbackService feedback, IDiscordRestUserAPI userApi,
+        IFeedbackService feedback, IDiscordRestUserAPI userApi,
         IDiscordRestGuildAPI guildApi)
     {
         _context = context;

--- a/src/Commands/BanCommandGroup.cs
+++ b/src/Commands/BanCommandGroup.cs
@@ -29,7 +29,7 @@ public class BanCommandGroup : CommandGroup
 {
     private readonly IDiscordRestChannelAPI _channelApi;
     private readonly ICommandContext _context;
-    private readonly FeedbackService _feedback;
+    private readonly IFeedbackService _feedback;
     private readonly IDiscordRestGuildAPI _guildApi;
     private readonly GuildDataService _guildData;
     private readonly IDiscordRestUserAPI _userApi;
@@ -37,7 +37,7 @@ public class BanCommandGroup : CommandGroup
 
     public BanCommandGroup(
         ICommandContext context, IDiscordRestChannelAPI channelApi, GuildDataService guildData,
-        FeedbackService feedback, IDiscordRestGuildAPI guildApi, IDiscordRestUserAPI userApi,
+        IFeedbackService feedback, IDiscordRestGuildAPI guildApi, IDiscordRestUserAPI userApi,
         UtilityService utility)
     {
         _context = context;

--- a/src/Commands/ClearCommandGroup.cs
+++ b/src/Commands/ClearCommandGroup.cs
@@ -27,14 +27,14 @@ public class ClearCommandGroup : CommandGroup
 {
     private readonly IDiscordRestChannelAPI _channelApi;
     private readonly ICommandContext _context;
-    private readonly FeedbackService _feedback;
+    private readonly IFeedbackService _feedback;
     private readonly GuildDataService _guildData;
     private readonly IDiscordRestUserAPI _userApi;
     private readonly UtilityService _utility;
 
     public ClearCommandGroup(
         IDiscordRestChannelAPI channelApi, ICommandContext context, GuildDataService guildData,
-        FeedbackService feedback, IDiscordRestUserAPI userApi, UtilityService utility)
+        IFeedbackService feedback, IDiscordRestUserAPI userApi, UtilityService utility)
     {
         _channelApi = channelApi;
         _context = context;

--- a/src/Commands/Events/ErrorLoggingPostExecutionEvent.cs
+++ b/src/Commands/Events/ErrorLoggingPostExecutionEvent.cs
@@ -18,10 +18,10 @@ namespace Octobot.Commands.Events;
 public class ErrorLoggingPostExecutionEvent : IPostExecutionEvent
 {
     private readonly ILogger<ErrorLoggingPostExecutionEvent> _logger;
-    private readonly FeedbackService _feedback;
+    private readonly IFeedbackService _feedback;
     private readonly IDiscordRestUserAPI _userApi;
 
-    public ErrorLoggingPostExecutionEvent(ILogger<ErrorLoggingPostExecutionEvent> logger, FeedbackService feedback,
+    public ErrorLoggingPostExecutionEvent(ILogger<ErrorLoggingPostExecutionEvent> logger, IFeedbackService feedback,
         IDiscordRestUserAPI userApi)
     {
         _logger = logger;

--- a/src/Commands/KickCommandGroup.cs
+++ b/src/Commands/KickCommandGroup.cs
@@ -26,7 +26,7 @@ public class KickCommandGroup : CommandGroup
 {
     private readonly IDiscordRestChannelAPI _channelApi;
     private readonly ICommandContext _context;
-    private readonly FeedbackService _feedback;
+    private readonly IFeedbackService _feedback;
     private readonly IDiscordRestGuildAPI _guildApi;
     private readonly GuildDataService _guildData;
     private readonly IDiscordRestUserAPI _userApi;
@@ -34,7 +34,7 @@ public class KickCommandGroup : CommandGroup
 
     public KickCommandGroup(
         ICommandContext context, IDiscordRestChannelAPI channelApi, GuildDataService guildData,
-        FeedbackService feedback, IDiscordRestGuildAPI guildApi, IDiscordRestUserAPI userApi,
+        IFeedbackService feedback, IDiscordRestGuildAPI guildApi, IDiscordRestUserAPI userApi,
         UtilityService utility)
     {
         _context = context;

--- a/src/Commands/MuteCommandGroup.cs
+++ b/src/Commands/MuteCommandGroup.cs
@@ -28,14 +28,14 @@ namespace Octobot.Commands;
 public class MuteCommandGroup : CommandGroup
 {
     private readonly ICommandContext _context;
-    private readonly FeedbackService _feedback;
+    private readonly IFeedbackService _feedback;
     private readonly IDiscordRestGuildAPI _guildApi;
     private readonly GuildDataService _guildData;
     private readonly IDiscordRestUserAPI _userApi;
     private readonly UtilityService _utility;
 
     public MuteCommandGroup(
-        ICommandContext context, GuildDataService guildData, FeedbackService feedback,
+        ICommandContext context, GuildDataService guildData, IFeedbackService feedback,
         IDiscordRestGuildAPI guildApi, IDiscordRestUserAPI userApi, UtilityService utility)
     {
         _context = context;

--- a/src/Commands/PingCommandGroup.cs
+++ b/src/Commands/PingCommandGroup.cs
@@ -27,13 +27,13 @@ public class PingCommandGroup : CommandGroup
     private readonly IDiscordRestChannelAPI _channelApi;
     private readonly DiscordGatewayClient _client;
     private readonly ICommandContext _context;
-    private readonly FeedbackService _feedback;
+    private readonly IFeedbackService _feedback;
     private readonly GuildDataService _guildData;
     private readonly IDiscordRestUserAPI _userApi;
 
     public PingCommandGroup(
         IDiscordRestChannelAPI channelApi, ICommandContext context, DiscordGatewayClient client,
-        GuildDataService guildData, FeedbackService feedback, IDiscordRestUserAPI userApi)
+        GuildDataService guildData, IFeedbackService feedback, IDiscordRestUserAPI userApi)
     {
         _channelApi = channelApi;
         _context = context;

--- a/src/Commands/RemindCommandGroup.cs
+++ b/src/Commands/RemindCommandGroup.cs
@@ -27,12 +27,12 @@ namespace Octobot.Commands;
 public class RemindCommandGroup : CommandGroup
 {
     private readonly ICommandContext _context;
-    private readonly FeedbackService _feedback;
+    private readonly IFeedbackService _feedback;
     private readonly GuildDataService _guildData;
     private readonly IDiscordRestUserAPI _userApi;
 
     public RemindCommandGroup(
-        ICommandContext context, GuildDataService guildData, FeedbackService feedback,
+        ICommandContext context, GuildDataService guildData, IFeedbackService feedback,
         IDiscordRestUserAPI userApi)
     {
         _context = context;

--- a/src/Commands/SettingsCommandGroup.cs
+++ b/src/Commands/SettingsCommandGroup.cs
@@ -54,14 +54,14 @@ public class SettingsCommandGroup : CommandGroup
     };
 
     private readonly ICommandContext _context;
-    private readonly FeedbackService _feedback;
+    private readonly IFeedbackService _feedback;
     private readonly GuildDataService _guildData;
     private readonly IDiscordRestUserAPI _userApi;
     private readonly UtilityService _utility;
 
     public SettingsCommandGroup(
         ICommandContext context, GuildDataService guildData,
-        FeedbackService feedback, IDiscordRestUserAPI userApi, UtilityService utility)
+        IFeedbackService feedback, IDiscordRestUserAPI userApi, UtilityService utility)
     {
         _context = context;
         _guildData = guildData;

--- a/src/Commands/ToolsCommandGroup.cs
+++ b/src/Commands/ToolsCommandGroup.cs
@@ -26,13 +26,13 @@ namespace Octobot.Commands;
 public class ToolsCommandGroup : CommandGroup
 {
     private readonly ICommandContext _context;
-    private readonly FeedbackService _feedback;
+    private readonly IFeedbackService _feedback;
     private readonly IDiscordRestGuildAPI _guildApi;
     private readonly GuildDataService _guildData;
     private readonly IDiscordRestUserAPI _userApi;
 
     public ToolsCommandGroup(
-        ICommandContext context, FeedbackService feedback,
+        ICommandContext context, IFeedbackService feedback,
         GuildDataService guildData, IDiscordRestGuildAPI guildApi,
         IDiscordRestUserAPI userApi, IDiscordRestChannelAPI channelApi)
     {

--- a/src/Extensions/FeedbackServiceExtensions.cs
+++ b/src/Extensions/FeedbackServiceExtensions.cs
@@ -7,7 +7,7 @@ namespace Octobot.Extensions;
 public static class FeedbackServiceExtensions
 {
     public static async Task<Result> SendContextualEmbedResultAsync(
-        this FeedbackService feedback, Result<Embed> embedResult, CancellationToken ct = default)
+        this IFeedbackService feedback, Result<Embed> embedResult, CancellationToken ct = default)
     {
         if (!embedResult.IsDefined(out var embed))
         {


### PR DESCRIPTION
This PR replaces usages of the `FeedbackService` implementation with the `IFeedbackService` interface. Using concrete implementations breaks the whole point of dependency injection, so it doesn't make sense to use them