### PR TITLE
Update CDN links for Octobot banner

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="https://mctaylors.ddns.net/cdn/octobot-banner.png" alt="Octobot banner"/>
+    <img src="https://cdn.mctaylors.ru/octobot-banner.png" alt="Octobot banner"/>
 </p>
 
 <a href="https://github.com/LabsDevelopment/Octobot/blob/master/LICENSE"><img src="https://img.shields.io/github/license/LabsDevelopment/Octobot?logo=git"></img></a>

--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -96,7 +96,7 @@ public class AboutCommandGroup : CommandGroup
         var embed = new EmbedBuilder().WithSmallTitle(Messages.AboutBot, bot)
             .WithDescription(builder.ToString())
             .WithColour(ColorsList.Cyan)
-            .WithImageUrl("https://mctaylors.ddns.net/cdn/octobot-banner.png")
+            .WithImageUrl("https://cdn.mctaylors.ru/octobot-banner.png")
             .Build();
 
         return await _feedback.SendContextualEmbedResultAsync(embed, ct);


### PR DESCRIPTION
Old CDN links are no longer working and they must be changed to new links to display Octobot banner properly.