### PR TITLE
Use TryGetValue instead of ContainsKey + index access to avoid double lookup

### DIFF
--- a/src/Services/Update/ScheduledEventUpdateService.cs
+++ b/src/Services/Update/ScheduledEventUpdateService.cs
@@ -104,14 +104,13 @@ public sealed class ScheduledEventUpdateService : BackgroundService
     {
         foreach (var @event in events)
         {
-            if (!data.ScheduledEvents.ContainsKey(@event.ID.Value))
+            if (!data.ScheduledEvents.TryGetValue(@event.ID.Value, out var eventData))
             {
                 data.ScheduledEvents.Add(@event.ID.Value,
                     new ScheduledEventData(@event.ID.Value, @event.Name, @event.ScheduledStartTime, @event.Status));
                 continue;
             }
 
-            var eventData = data.ScheduledEvents[@event.ID.Value];
             eventData.Name = @event.Name;
             eventData.ScheduledStartTime = @event.ScheduledStartTime;
             if (!eventData.ScheduleOnStatusUpdated)


### PR DESCRIPTION
This PR fixes an issue that is currently causing CI to fail in all pull requests:
`Notice: "[CA1854] Prefer a 'TryGetValue' call over a Dictionary indexer access guarded by a 'ContainsKey' check to avoid double lookup" on /home/runner/work/Octobot/Octobot/src/Services/Update/ScheduledEventUpdateService.cs(107,4168)`
The issue is resolved by following the advice mentioned in the notice.