### PR TITLE
Put edited message in cache if it's not in cache already

### DIFF
--- a/src/Responders/MessageEditedResponder.cs
+++ b/src/Responders/MessageEditedResponder.cs
@@ -72,7 +72,8 @@ public class MessageEditedResponder : IResponder<IMessageUpdate>
             cacheKey, ct);
         if (!messageResult.IsDefined(out var message))
         {
-            return Result.FromError(messageResult);
+            _ = _channelApi.GetChannelMessageAsync(channelId, messageId, ct);
+            return Result.FromSuccess();
         }
 
         if (message.Content == newContent)


### PR DESCRIPTION
Closes #183 

In addition to the fix, now no error will be returned if the message doesn't exist in the cache as that is a (relatively) normal occurrence and isn't an indicator of an issue with the bot or its configuration