### PR TITLE
Add StringBuilder & Markdown extensions

### DIFF
--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -88,7 +88,7 @@ public class AboutCommandGroup : CommandGroup
                 guildId, dev.Id, ct);
             var tag = guildMemberResult.IsSuccess ? $"<@{dev.Id}>" : $"@{dev.Username}";
 
-            builder.AppendLine($"- {tag} — {$"AboutDeveloper@{dev.Username}".Localized()}");
+            builder.AppendBulletPointLine($"{tag} — {$"AboutDeveloper@{dev.Username}".Localized()}");
         }
 
         builder.Append($"### [{Messages.AboutTitleRepository}](https://github.com/LabsDevelopment/Octobot)");

--- a/src/Commands/BanCommandGroup.cs
+++ b/src/Commands/BanCommandGroup.cs
@@ -135,10 +135,10 @@ public class BanCommandGroup : CommandGroup
             return await _feedback.SendContextualEmbedResultAsync(errorEmbed, ct);
         }
 
-        var builder = new StringBuilder().AppendLineWithBullet(string.Format(Messages.DescriptionActionReason, reason));
+        var builder = new StringBuilder().AppendBulletPointLine(string.Format(Messages.DescriptionActionReason, reason));
         if (duration is not null)
         {
-            builder.AppendWithBullet(
+            builder.AppendBulletPoint(
                 string.Format(
                     Messages.DescriptionActionExpiresAt,
                     Markdown.Timestamp(DateTimeOffset.UtcNow.Add(duration.Value))));
@@ -273,7 +273,7 @@ public class BanCommandGroup : CommandGroup
             .WithColour(ColorsList.Green).Build();
 
         var title = string.Format(Messages.UserUnbanned, target.GetTag());
-        var description = new StringBuilder().AppendWithBullet(string.Format(Messages.DescriptionActionReason, reason));
+        var description = new StringBuilder().AppendBulletPoint(string.Format(Messages.DescriptionActionReason, reason));
         var logResult = _utility.LogActionAsync(
             data.Settings, channelId, executor, title, description.ToString(), target, ColorsList.Green, ct: ct);
         if (!logResult.IsSuccess)

--- a/src/Commands/BanCommandGroup.cs
+++ b/src/Commands/BanCommandGroup.cs
@@ -135,11 +135,10 @@ public class BanCommandGroup : CommandGroup
             return await _feedback.SendContextualEmbedResultAsync(errorEmbed, ct);
         }
 
-        var builder = new StringBuilder().Append("- ")
-            .AppendLine(string.Format(Messages.DescriptionActionReason, reason));
+        var builder = new StringBuilder().AppendLineWithBullet(string.Format(Messages.DescriptionActionReason, reason));
         if (duration is not null)
         {
-            builder.Append("- ").Append(
+            builder.AppendWithBullet(
                 string.Format(
                     Messages.DescriptionActionExpiresAt,
                     Markdown.Timestamp(DateTimeOffset.UtcNow.Add(duration.Value))));
@@ -274,8 +273,7 @@ public class BanCommandGroup : CommandGroup
             .WithColour(ColorsList.Green).Build();
 
         var title = string.Format(Messages.UserUnbanned, target.GetTag());
-        var description = new StringBuilder().Append("- ")
-            .Append(string.Format(Messages.DescriptionActionReason, reason));
+        var description = new StringBuilder().AppendWithBullet(string.Format(Messages.DescriptionActionReason, reason));
         var logResult = _utility.LogActionAsync(
             data.Settings, channelId, executor, title, description.ToString(), target, ColorsList.Green, ct: ct);
         if (!logResult.IsSuccess)

--- a/src/Commands/KickCommandGroup.cs
+++ b/src/Commands/KickCommandGroup.cs
@@ -13,7 +13,6 @@ using Remora.Discord.Commands.Conditions;
 using Remora.Discord.Commands.Contexts;
 using Remora.Discord.Commands.Feedback.Services;
 using Remora.Discord.Extensions.Embeds;
-using Remora.Discord.Extensions.Formatting;
 using Remora.Rest.Core;
 using Remora.Results;
 

--- a/src/Commands/KickCommandGroup.cs
+++ b/src/Commands/KickCommandGroup.cs
@@ -134,7 +134,7 @@ public class KickCommandGroup : CommandGroup
         {
             var dmEmbed = new EmbedBuilder().WithGuildTitle(guild)
                 .WithTitle(Messages.YouWereKicked)
-                .WithDescription($"- {string.Format(Messages.DescriptionActionReason, reason)}")
+                .WithDescription(string.Format(Messages.DescriptionActionReason, reason).AddBulletPoint())
                 .WithActionFooter(executor)
                 .WithCurrentTimestamp()
                 .WithColour(ColorsList.Red)
@@ -159,7 +159,7 @@ public class KickCommandGroup : CommandGroup
         data.GetOrCreateMemberData(target.ID).Roles.Clear();
 
         var title = string.Format(Messages.UserKicked, target.GetTag());
-        var description = $"- {string.Format(Messages.DescriptionActionReason, reason)}";
+        var description = string.Format(Messages.DescriptionActionReason, reason).AddBulletPoint();
         var logResult = _utility.LogActionAsync(
             data.Settings, channelId, executor, title, description, target, ColorsList.Red, ct: ct);
         if (!logResult.IsSuccess)

--- a/src/Commands/KickCommandGroup.cs
+++ b/src/Commands/KickCommandGroup.cs
@@ -13,6 +13,7 @@ using Remora.Discord.Commands.Conditions;
 using Remora.Discord.Commands.Contexts;
 using Remora.Discord.Commands.Feedback.Services;
 using Remora.Discord.Extensions.Embeds;
+using Remora.Discord.Extensions.Formatting;
 using Remora.Rest.Core;
 using Remora.Results;
 
@@ -134,7 +135,7 @@ public class KickCommandGroup : CommandGroup
         {
             var dmEmbed = new EmbedBuilder().WithGuildTitle(guild)
                 .WithTitle(Messages.YouWereKicked)
-                .WithDescription(string.Format(Messages.DescriptionActionReason, reason).AddBulletPoint())
+                .WithDescription(MarkdownExtensions.BulletPoint(string.Format(Messages.DescriptionActionReason, reason)))
                 .WithActionFooter(executor)
                 .WithCurrentTimestamp()
                 .WithColour(ColorsList.Red)
@@ -159,7 +160,7 @@ public class KickCommandGroup : CommandGroup
         data.GetOrCreateMemberData(target.ID).Roles.Clear();
 
         var title = string.Format(Messages.UserKicked, target.GetTag());
-        var description = string.Format(Messages.DescriptionActionReason, reason).AddBulletPoint();
+        var description = MarkdownExtensions.BulletPoint(string.Format(Messages.DescriptionActionReason, reason));
         var logResult = _utility.LogActionAsync(
             data.Settings, channelId, executor, title, description, target, ColorsList.Red, ct: ct);
         if (!logResult.IsSuccess)

--- a/src/Commands/MuteCommandGroup.cs
+++ b/src/Commands/MuteCommandGroup.cs
@@ -136,8 +136,8 @@ public class MuteCommandGroup : CommandGroup
         }
 
         var title = string.Format(Messages.UserMuted, target.GetTag());
-        var description = new StringBuilder().Append("- ").AppendLine(string.Format(Messages.DescriptionActionReason, reason))
-            .Append("- ").Append(string.Format(
+        var description = new StringBuilder().AppendLineWithBullet(string.Format(Messages.DescriptionActionReason, reason))
+            .AppendWithBullet(string.Format(
                 Messages.DescriptionActionExpiresAt, Markdown.Timestamp(until))).ToString();
 
         var logResult = _utility.LogActionAsync(

--- a/src/Commands/MuteCommandGroup.cs
+++ b/src/Commands/MuteCommandGroup.cs
@@ -325,7 +325,7 @@ public class MuteCommandGroup : CommandGroup
         }
 
         var title = string.Format(Messages.UserUnmuted, target.GetTag());
-        var description = string.Format(Messages.DescriptionActionReason, reason).AddBulletPoint();
+        var description = MarkdownExtensions.BulletPoint(string.Format(Messages.DescriptionActionReason, reason));
         var logResult = _utility.LogActionAsync(
             data.Settings, channelId, executor, title, description, target, ColorsList.Green, ct: ct);
         if (!logResult.IsSuccess)

--- a/src/Commands/MuteCommandGroup.cs
+++ b/src/Commands/MuteCommandGroup.cs
@@ -325,7 +325,7 @@ public class MuteCommandGroup : CommandGroup
         }
 
         var title = string.Format(Messages.UserUnmuted, target.GetTag());
-        var description = $"- {string.Format(Messages.DescriptionActionReason, reason)}";
+        var description = string.Format(Messages.DescriptionActionReason, reason).AddBulletPoint();
         var logResult = _utility.LogActionAsync(
             data.Settings, channelId, executor, title, description, target, ColorsList.Green, ct: ct);
         if (!logResult.IsSuccess)

--- a/src/Commands/MuteCommandGroup.cs
+++ b/src/Commands/MuteCommandGroup.cs
@@ -136,8 +136,8 @@ public class MuteCommandGroup : CommandGroup
         }
 
         var title = string.Format(Messages.UserMuted, target.GetTag());
-        var description = new StringBuilder().AppendLineWithBullet(string.Format(Messages.DescriptionActionReason, reason))
-            .AppendWithBullet(string.Format(
+        var description = new StringBuilder().AppendBulletPointLine(string.Format(Messages.DescriptionActionReason, reason))
+            .AppendBulletPoint(string.Format(
                 Messages.DescriptionActionExpiresAt, Markdown.Timestamp(until))).ToString();
 
         var logResult = _utility.LogActionAsync(

--- a/src/Commands/RemindCommandGroup.cs
+++ b/src/Commands/RemindCommandGroup.cs
@@ -90,9 +90,9 @@ public class RemindCommandGroup : CommandGroup
         for (var i = 0; i < data.Reminders.Count; i++)
         {
             var reminder = data.Reminders[i];
-            builder.AppendLineWithBullet(string.Format(Messages.ReminderPosition, Markdown.InlineCode((i + 1).ToString())))
-                .AppendLineWithSubBullet(string.Format(Messages.ReminderText, Markdown.InlineCode(reminder.Text)))
-                .AppendLineWithSubBullet(string.Format(Messages.ReminderTime, Markdown.Timestamp(reminder.At)));
+            builder.AppendBulletPointLine(string.Format(Messages.ReminderPosition, Markdown.InlineCode((i + 1).ToString())))
+                .AppendSubBulletPointLine(string.Format(Messages.ReminderText, Markdown.InlineCode(reminder.Text)))
+                .AppendSubBulletPointLine(string.Format(Messages.ReminderTime, Markdown.Timestamp(reminder.At)));
         }
 
         var embed = new EmbedBuilder().WithSmallTitle(
@@ -154,9 +154,9 @@ public class RemindCommandGroup : CommandGroup
                 Text = text
             });
 
-        var builder = new StringBuilder().AppendLineWithBullet(string.Format(
+        var builder = new StringBuilder().AppendBulletPointLine(string.Format(
                 Messages.ReminderText, Markdown.InlineCode(text)))
-            .AppendWithBullet(string.Format(Messages.ReminderTime, Markdown.Timestamp(remindAt)));
+            .AppendBulletPoint(string.Format(Messages.ReminderTime, Markdown.Timestamp(remindAt)));
 
         var embed = new EmbedBuilder().WithSmallTitle(
                 string.Format(Messages.ReminderCreated, executor.GetTag()), executor)
@@ -214,8 +214,8 @@ public class RemindCommandGroup : CommandGroup
         var reminder = data.Reminders[index];
 
         var description = new StringBuilder()
-            .AppendLineWithBullet(string.Format(Messages.ReminderText, Markdown.InlineCode(reminder.Text)))
-            .AppendLineWithBullet(string.Format(Messages.ReminderTime, Markdown.Timestamp(reminder.At)));
+            .AppendBulletPointLine(string.Format(Messages.ReminderText, Markdown.InlineCode(reminder.Text)))
+            .AppendBulletPointLine(string.Format(Messages.ReminderTime, Markdown.Timestamp(reminder.At)));
 
         data.Reminders.RemoveAt(index);
 

--- a/src/Commands/RemindCommandGroup.cs
+++ b/src/Commands/RemindCommandGroup.cs
@@ -90,10 +90,9 @@ public class RemindCommandGroup : CommandGroup
         for (var i = 0; i < data.Reminders.Count; i++)
         {
             var reminder = data.Reminders[i];
-            builder.Append("- ").AppendLine(string.Format(Messages.ReminderPosition, Markdown.InlineCode((i + 1).ToString())))
-                .Append(" - ").AppendLine(string.Format(Messages.ReminderText, Markdown.InlineCode(reminder.Text)))
-                .Append(" - ")
-                .AppendLine(string.Format(Messages.ReminderTime, Markdown.Timestamp(reminder.At)));
+            builder.AppendLineWithBullet(string.Format(Messages.ReminderPosition, Markdown.InlineCode((i + 1).ToString())))
+                .AppendLineWithSubBullet(string.Format(Messages.ReminderText, Markdown.InlineCode(reminder.Text)))
+                .AppendLineWithSubBullet(string.Format(Messages.ReminderTime, Markdown.Timestamp(reminder.At)));
         }
 
         var embed = new EmbedBuilder().WithSmallTitle(
@@ -155,9 +154,9 @@ public class RemindCommandGroup : CommandGroup
                 Text = text
             });
 
-        var builder = new StringBuilder().Append("- ").AppendLine(string.Format(
+        var builder = new StringBuilder().AppendLineWithBullet(string.Format(
                 Messages.ReminderText, Markdown.InlineCode(text)))
-            .Append("- ").Append(string.Format(Messages.ReminderTime, Markdown.Timestamp(remindAt)));
+            .AppendWithBullet(string.Format(Messages.ReminderTime, Markdown.Timestamp(remindAt)));
 
         var embed = new EmbedBuilder().WithSmallTitle(
                 string.Format(Messages.ReminderCreated, executor.GetTag()), executor)
@@ -215,8 +214,8 @@ public class RemindCommandGroup : CommandGroup
         var reminder = data.Reminders[index];
 
         var description = new StringBuilder()
-            .Append("- ").AppendLine(string.Format(Messages.ReminderText, Markdown.InlineCode(reminder.Text)))
-            .Append("- ").AppendLine(string.Format(Messages.ReminderTime, Markdown.Timestamp(reminder.At)));
+            .AppendLineWithBullet(string.Format(Messages.ReminderText, Markdown.InlineCode(reminder.Text)))
+            .AppendLineWithBullet(string.Format(Messages.ReminderTime, Markdown.Timestamp(reminder.At)));
 
         data.Reminders.RemoveAt(index);
 

--- a/src/Commands/SettingsCommandGroup.cs
+++ b/src/Commands/SettingsCommandGroup.cs
@@ -138,9 +138,9 @@ public class SettingsCommandGroup : CommandGroup
             var optionName = AllOptions[i].Name;
             var optionValue = AllOptions[i].Display(cfg);
 
-            description.AppendLine($"- {$"Settings{optionName}".Localized()}")
-                .Append($" - {Markdown.InlineCode(optionName)}: ")
-                .AppendLine(optionValue);
+            description.AppendBulletPointLine($"Settings{optionName}".Localized())
+                .AppendSubBulletPoint(Markdown.InlineCode(optionName))
+                .Append(": ").AppendLine(optionValue);
         }
 
         var embed = new EmbedBuilder().WithSmallTitle(Messages.SettingsListTitle, bot)

--- a/src/Commands/ToolsCommandGroup.cs
+++ b/src/Commands/ToolsCommandGroup.cs
@@ -102,11 +102,11 @@ public class ToolsCommandGroup : CommandGroup
 
         if (target.GlobalName is not null)
         {
-            builder.AppendLineWithBullet(Messages.UserInfoDisplayName)
+            builder.AppendBulletPointLine(Messages.UserInfoDisplayName)
                 .AppendLine(Markdown.InlineCode(target.GlobalName));
         }
 
-        builder.AppendLineWithBullet(Messages.UserInfoDiscordUserSince)
+        builder.AppendBulletPointLine(Messages.UserInfoDiscordUserSince)
             .AppendLine(Markdown.Timestamp(target.ID.Timestamp));
 
         var memberData = data.GetOrCreateMemberData(target.ID);
@@ -170,23 +170,23 @@ public class ToolsCommandGroup : CommandGroup
     {
         if (guildMember.Nickname.IsDefined(out var nickname))
         {
-            builder.AppendLineWithBullet(Messages.UserInfoGuildNickname)
+            builder.AppendBulletPointLine(Messages.UserInfoGuildNickname)
                 .AppendLine(Markdown.InlineCode(nickname));
         }
 
-        builder.AppendLineWithBullet(Messages.UserInfoGuildMemberSince)
+        builder.AppendBulletPointLine(Messages.UserInfoGuildMemberSince)
             .AppendLine(Markdown.Timestamp(guildMember.JoinedAt));
 
         if (guildMember.PremiumSince.IsDefined(out var premiumSince))
         {
-            builder.AppendLineWithBullet(Messages.UserInfoGuildMemberPremiumSince)
+            builder.AppendBulletPointLine(Messages.UserInfoGuildMemberPremiumSince)
                 .AppendLine(Markdown.Timestamp(premiumSince.Value));
             color = ColorsList.Magenta;
         }
 
         if (guildMember.Roles.Count > 0)
         {
-            builder.AppendLineWithBullet(Messages.UserInfoGuildRoles);
+            builder.AppendBulletPointLine(Messages.UserInfoGuildRoles);
             for (var i = 0; i < guildMember.Roles.Count - 1; i++)
             {
                 builder.Append($"<@&{guildMember.Roles[i]}>, ");
@@ -202,30 +202,30 @@ public class ToolsCommandGroup : CommandGroup
     {
         if (memberData.BannedUntil < DateTimeOffset.MaxValue)
         {
-            builder.AppendLineWithBullet(Messages.UserInfoBanned)
-                .AppendLineWithSubBullet(string.Format(
+            builder.AppendBulletPointLine(Messages.UserInfoBanned)
+                .AppendSubBulletPointLine(string.Format(
                     Messages.DescriptionActionExpiresAt, Markdown.Timestamp(memberData.BannedUntil.Value)));
             return;
         }
 
-        builder.AppendLineWithBullet(Messages.UserInfoBannedPermanently);
+        builder.AppendBulletPointLine(Messages.UserInfoBannedPermanently);
     }
 
     private static void AppendMuteInformation(
         MemberData memberData, DateTimeOffset? communicationDisabledUntil, StringBuilder builder)
     {
-        builder.AppendLineWithBullet(Messages.UserInfoMuted);
+        builder.AppendBulletPointLine(Messages.UserInfoMuted);
         if (memberData.MutedUntil is not null && DateTimeOffset.UtcNow <= memberData.MutedUntil)
         {
-            builder.AppendLineWithSubBullet(Messages.UserInfoMutedByMuteRole)
-                .AppendLineWithSubBullet(string.Format(
+            builder.AppendSubBulletPointLine(Messages.UserInfoMutedByMuteRole)
+                .AppendSubBulletPointLine(string.Format(
                     Messages.DescriptionActionExpiresAt, Markdown.Timestamp(memberData.MutedUntil.Value)));
         }
 
         if (communicationDisabledUntil is not null)
         {
-            builder.AppendLineWithSubBullet(Messages.UserInfoMutedByTimeout)
-                .AppendLineWithSubBullet(string.Format(
+            builder.AppendSubBulletPointLine(Messages.UserInfoMutedByTimeout)
+                .AppendSubBulletPointLine(string.Format(
                     Messages.DescriptionActionExpiresAt, Markdown.Timestamp(communicationDisabledUntil.Value)));
         }
     }
@@ -282,13 +282,13 @@ public class ToolsCommandGroup : CommandGroup
 
         if (guild.Description is not null)
         {
-            description.AppendLineWithBullet(Messages.GuildInfoDescription)
+            description.AppendBulletPointLine(Messages.GuildInfoDescription)
                 .AppendLine(Markdown.InlineCode(guild.Description));
         }
 
-        description.AppendLineWithBullet(Messages.GuildInfoCreatedAt)
+        description.AppendBulletPointLine(Messages.GuildInfoCreatedAt)
             .AppendLine(Markdown.Timestamp(guild.ID.Timestamp))
-            .AppendLineWithBullet(Messages.GuildInfoOwner)
+            .AppendBulletPointLine(Messages.GuildInfoOwner)
             .AppendLine(Mention.User(guild.OwnerID));
 
         var embedColor = ColorsList.Cyan;
@@ -296,9 +296,9 @@ public class ToolsCommandGroup : CommandGroup
         if (guild.PremiumTier > PremiumTier.None)
         {
             description.Append("### ").AppendLine(Messages.GuildInfoServerBoost)
-                .AppendWithBullet(Messages.GuildInfoBoostTier)
+                .AppendBulletPoint(Messages.GuildInfoBoostTier)
                 .Append(": ").AppendLine(Markdown.InlineCode(guild.PremiumTier.ToString()))
-                .AppendWithBullet(Messages.GuildInfoBoostCount)
+                .AppendBulletPoint(Messages.GuildInfoBoostCount)
                 .Append(": ").AppendLine(Markdown.InlineCode(guild.PremiumSubscriptionCount.ToString()));
             embedColor = ColorsList.Magenta;
         }
@@ -362,14 +362,14 @@ public class ToolsCommandGroup : CommandGroup
 
         var description = new StringBuilder().Append("# ").Append(i);
 
-        description.AppendLine().AppendWithBullet(string.Format(
+        description.AppendLine().AppendBulletPoint(string.Format(
             Messages.RandomMin, Markdown.InlineCode(min.ToString())));
         if (secondNullable is null && first >= secondDefault)
         {
             description.Append(' ').Append(Messages.Default);
         }
 
-        description.AppendLine().AppendWithBullet(string.Format(
+        description.AppendLine().AppendBulletPoint(string.Format(
             Messages.RandomMax, Markdown.InlineCode(max.ToString())));
         if (secondNullable is null && first < secondDefault)
         {
@@ -449,7 +449,7 @@ public class ToolsCommandGroup : CommandGroup
 
         foreach (var markdownTimestamp in AllStyles.Select(style => Markdown.Timestamp(timestamp, style)))
         {
-            description.AppendWithBullet(Markdown.InlineCode(markdownTimestamp))
+            description.AppendBulletPoint(Markdown.InlineCode(markdownTimestamp))
                 .Append(" → ").AppendLine(markdownTimestamp);
         }
 

--- a/src/Commands/ToolsCommandGroup.cs
+++ b/src/Commands/ToolsCommandGroup.cs
@@ -102,11 +102,11 @@ public class ToolsCommandGroup : CommandGroup
 
         if (target.GlobalName is not null)
         {
-            builder.Append("- ").AppendLine(Messages.UserInfoDisplayName)
+            builder.AppendLineWithBullet(Messages.UserInfoDisplayName)
                 .AppendLine(Markdown.InlineCode(target.GlobalName));
         }
 
-        builder.Append("- ").AppendLine(Messages.UserInfoDiscordUserSince)
+        builder.AppendLineWithBullet(Messages.UserInfoDiscordUserSince)
             .AppendLine(Markdown.Timestamp(target.ID.Timestamp));
 
         var memberData = data.GetOrCreateMemberData(target.ID);
@@ -170,23 +170,23 @@ public class ToolsCommandGroup : CommandGroup
     {
         if (guildMember.Nickname.IsDefined(out var nickname))
         {
-            builder.Append("- ").AppendLine(Messages.UserInfoGuildNickname)
+            builder.AppendLineWithBullet(Messages.UserInfoGuildNickname)
                 .AppendLine(Markdown.InlineCode(nickname));
         }
 
-        builder.Append("- ").AppendLine(Messages.UserInfoGuildMemberSince)
+        builder.AppendLineWithBullet(Messages.UserInfoGuildMemberSince)
             .AppendLine(Markdown.Timestamp(guildMember.JoinedAt));
 
         if (guildMember.PremiumSince.IsDefined(out var premiumSince))
         {
-            builder.Append("- ").AppendLine(Messages.UserInfoGuildMemberPremiumSince)
+            builder.AppendLineWithBullet(Messages.UserInfoGuildMemberPremiumSince)
                 .AppendLine(Markdown.Timestamp(premiumSince.Value));
             color = ColorsList.Magenta;
         }
 
         if (guildMember.Roles.Count > 0)
         {
-            builder.Append("- ").AppendLine(Messages.UserInfoGuildRoles);
+            builder.AppendLineWithBullet(Messages.UserInfoGuildRoles);
             for (var i = 0; i < guildMember.Roles.Count - 1; i++)
             {
                 builder.Append($"<@&{guildMember.Roles[i]}>, ");
@@ -202,30 +202,30 @@ public class ToolsCommandGroup : CommandGroup
     {
         if (memberData.BannedUntil < DateTimeOffset.MaxValue)
         {
-            builder.Append("- ").AppendLine(Messages.UserInfoBanned)
-                .Append(" - ").AppendLine(string.Format(
+            builder.AppendLineWithBullet(Messages.UserInfoBanned)
+                .AppendLineWithSubBullet(string.Format(
                     Messages.DescriptionActionExpiresAt, Markdown.Timestamp(memberData.BannedUntil.Value)));
             return;
         }
 
-        builder.Append("- ").AppendLine(Messages.UserInfoBannedPermanently);
+        builder.AppendLineWithBullet(Messages.UserInfoBannedPermanently);
     }
 
     private static void AppendMuteInformation(
         MemberData memberData, DateTimeOffset? communicationDisabledUntil, StringBuilder builder)
     {
-        builder.Append("- ").AppendLine(Messages.UserInfoMuted);
+        builder.AppendLineWithBullet(Messages.UserInfoMuted);
         if (memberData.MutedUntil is not null && DateTimeOffset.UtcNow <= memberData.MutedUntil)
         {
-            builder.Append(" - ").AppendLine(Messages.UserInfoMutedByMuteRole)
-                .Append(" - ").AppendLine(string.Format(
+            builder.AppendLineWithSubBullet(Messages.UserInfoMutedByMuteRole)
+                .AppendLineWithSubBullet(string.Format(
                     Messages.DescriptionActionExpiresAt, Markdown.Timestamp(memberData.MutedUntil.Value)));
         }
 
         if (communicationDisabledUntil is not null)
         {
-            builder.Append(" - ").AppendLine(Messages.UserInfoMutedByTimeout)
-                .Append(" - ").AppendLine(string.Format(
+            builder.AppendLineWithSubBullet(Messages.UserInfoMutedByTimeout)
+                .AppendLineWithSubBullet(string.Format(
                     Messages.DescriptionActionExpiresAt, Markdown.Timestamp(communicationDisabledUntil.Value)));
         }
     }
@@ -282,13 +282,13 @@ public class ToolsCommandGroup : CommandGroup
 
         if (guild.Description is not null)
         {
-            description.Append("- ").AppendLine(Messages.GuildInfoDescription)
+            description.AppendLineWithBullet(Messages.GuildInfoDescription)
                 .AppendLine(Markdown.InlineCode(guild.Description));
         }
 
-        description.Append("- ").AppendLine(Messages.GuildInfoCreatedAt)
+        description.AppendLineWithBullet(Messages.GuildInfoCreatedAt)
             .AppendLine(Markdown.Timestamp(guild.ID.Timestamp))
-            .Append("- ").AppendLine(Messages.GuildInfoOwner)
+            .AppendLineWithBullet(Messages.GuildInfoOwner)
             .AppendLine(Mention.User(guild.OwnerID));
 
         var embedColor = ColorsList.Cyan;
@@ -296,9 +296,9 @@ public class ToolsCommandGroup : CommandGroup
         if (guild.PremiumTier > PremiumTier.None)
         {
             description.Append("### ").AppendLine(Messages.GuildInfoServerBoost)
-                .Append("- ").Append(Messages.GuildInfoBoostTier)
+                .AppendWithBullet(Messages.GuildInfoBoostTier)
                 .Append(": ").AppendLine(Markdown.InlineCode(guild.PremiumTier.ToString()))
-                .Append("- ").Append(Messages.GuildInfoBoostCount)
+                .AppendWithBullet(Messages.GuildInfoBoostCount)
                 .Append(": ").AppendLine(Markdown.InlineCode(guild.PremiumSubscriptionCount.ToString()));
             embedColor = ColorsList.Magenta;
         }
@@ -362,14 +362,14 @@ public class ToolsCommandGroup : CommandGroup
 
         var description = new StringBuilder().Append("# ").Append(i);
 
-        description.AppendLine().Append("- ").Append(string.Format(
+        description.AppendLine().AppendWithBullet(string.Format(
             Messages.RandomMin, Markdown.InlineCode(min.ToString())));
         if (secondNullable is null && first >= secondDefault)
         {
             description.Append(' ').Append(Messages.Default);
         }
 
-        description.AppendLine().Append("- ").Append(string.Format(
+        description.AppendLine().AppendWithBullet(string.Format(
             Messages.RandomMax, Markdown.InlineCode(max.ToString())));
         if (secondNullable is null && first < secondDefault)
         {
@@ -449,7 +449,7 @@ public class ToolsCommandGroup : CommandGroup
 
         foreach (var markdownTimestamp in AllStyles.Select(style => Markdown.Timestamp(timestamp, style)))
         {
-            description.Append("- ").Append(Markdown.InlineCode(markdownTimestamp))
+            description.AppendWithBullet(Markdown.InlineCode(markdownTimestamp))
                 .Append(" → ").AppendLine(markdownTimestamp);
         }
 

--- a/src/Extensions/MarkdownExtensions.cs
+++ b/src/Extensions/MarkdownExtensions.cs
@@ -1,0 +1,16 @@
+﻿namespace Octobot.Extensions;
+
+public static class MarkdownExtensions
+{
+    /// <summary>
+    /// Formats a string to use Markdown Bullet formatting.
+    /// </summary>
+    /// <param name="text">The input text to format.</param>
+    /// <returns>
+    /// A markdown-formatted bullet string.
+    /// </returns>
+    public static string BulletPoint(string text)
+    {
+        return $"- {text}";
+    }
+}

--- a/src/Extensions/StringBuilderExtensions.cs
+++ b/src/Extensions/StringBuilderExtensions.cs
@@ -4,17 +4,17 @@ namespace Octobot.Extensions;
 
 public static class StringBuilderExtensions
 {
-    public static StringBuilder AppendWithBullet(this StringBuilder builder, string? text)
+    public static StringBuilder AppendBulletPoint(this StringBuilder builder, string? text)
     {
         return builder.Append("- ").Append(text);
     }
 
-    public static StringBuilder AppendLineWithBullet(this StringBuilder builder, string? text)
+    public static StringBuilder AppendBulletPointLine(this StringBuilder builder, string? text)
     {
         return builder.Append("- ").AppendLine(text);
     }
 
-    public static StringBuilder AppendLineWithSubBullet(this StringBuilder builder, string? text)
+    public static StringBuilder AppendSubBulletPointLine(this StringBuilder builder, string? text)
     {
         return builder.Append(" - ").AppendLine(text);
     }

--- a/src/Extensions/StringBuilderExtensions.cs
+++ b/src/Extensions/StringBuilderExtensions.cs
@@ -9,6 +9,11 @@ public static class StringBuilderExtensions
         return builder.Append("- ").Append(text);
     }
 
+    public static StringBuilder AppendSubBulletPoint(this StringBuilder builder, string? text)
+    {
+        return builder.Append(" - ").Append(text);
+    }
+
     public static StringBuilder AppendBulletPointLine(this StringBuilder builder, string? text)
     {
         return builder.Append("- ").AppendLine(text);

--- a/src/Extensions/StringBuilderExtensions.cs
+++ b/src/Extensions/StringBuilderExtensions.cs
@@ -4,23 +4,59 @@ namespace Octobot.Extensions;
 
 public static class StringBuilderExtensions
 {
-    public static StringBuilder AppendBulletPoint(this StringBuilder builder, string? text)
+    /// <summary>
+    ///     Appends the input string with Markdown Bullet formatting to the specified <see cref="StringBuilder" /> object.
+    /// </summary>
+    /// <param name="builder">The <see cref="StringBuilder" /> object.</param>
+    /// <param name="value">The string to append with bullet point.</param>
+    /// <returns>
+    ///     The builder with the appended string with Markdown Bullet formatting.
+    /// </returns>
+    public static StringBuilder AppendBulletPoint(this StringBuilder builder, string? value)
     {
-        return builder.Append("- ").Append(text);
+        return builder.Append("- ").Append(value);
     }
 
-    public static StringBuilder AppendSubBulletPoint(this StringBuilder builder, string? text)
+    /// <summary>
+    ///     Appends the input string with Markdown Sub-Bullet formatting to the specified <see cref="StringBuilder" /> object.
+    /// </summary>
+    /// <param name="builder">The <see cref="StringBuilder" /> object.</param>
+    /// <param name="value">The string to append with sub-bullet point.</param>
+    /// <returns>
+    ///     The builder with the appended string with Markdown Sub-Bullet formatting.
+    /// </returns>
+    public static StringBuilder AppendSubBulletPoint(this StringBuilder builder, string? value)
     {
-        return builder.Append(" - ").Append(text);
+        return builder.Append(" - ").Append(value);
     }
 
-    public static StringBuilder AppendBulletPointLine(this StringBuilder builder, string? text)
+    /// <summary>
+    ///     Appends the input string with Markdown Bullet formatting followed by
+    ///     the default line terminator to the end of specified <see cref="StringBuilder" /> object.
+    /// </summary>
+    /// <param name="builder">The <see cref="StringBuilder" /> object.</param>
+    /// <param name="value">The string to append with bullet point.</param>
+    /// <returns>
+    ///     The builder with the appended string with Markdown Bullet formatting
+    ///     and default line terminator at the end.
+    /// </returns>
+    public static StringBuilder AppendBulletPointLine(this StringBuilder builder, string? value)
     {
-        return builder.Append("- ").AppendLine(text);
+        return builder.Append("- ").AppendLine(value);
     }
 
-    public static StringBuilder AppendSubBulletPointLine(this StringBuilder builder, string? text)
+    /// <summary>
+    ///     Appends the input string with Markdown Sub-Bullet formatting followed by
+    ///     the default line terminator to the end of specified <see cref="StringBuilder" /> object.
+    /// </summary>
+    /// <param name="builder">The <see cref="StringBuilder" /> object.</param>
+    /// <param name="value">The string to append with sub-bullet point.</param>
+    /// <returns>
+    ///     The builder with the appended string with Markdown Sub-Bullet formatting
+    ///     and default line terminator at the end.
+    /// </returns>
+    public static StringBuilder AppendSubBulletPointLine(this StringBuilder builder, string? value)
     {
-        return builder.Append(" - ").AppendLine(text);
+        return builder.Append(" - ").AppendLine(value);
     }
 }

--- a/src/Extensions/StringBuilderExtensions.cs
+++ b/src/Extensions/StringBuilderExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.Text;
+
+namespace Octobot.Extensions;
+
+public static class StringBuilderExtensions
+{
+    public static StringBuilder AppendWithBullet(this StringBuilder builder, string? text)
+    {
+        return builder.Append("- ").Append(text);
+    }
+
+    public static StringBuilder AppendLineWithBullet(this StringBuilder builder, string? text)
+    {
+        return builder.Append("- ").AppendLine(text);
+    }
+
+    public static StringBuilder AppendLineWithSubBullet(this StringBuilder builder, string? text)
+    {
+        return builder.Append(" - ").AppendLine(text);
+    }
+}

--- a/src/Extensions/StringExtensions.cs
+++ b/src/Extensions/StringExtensions.cs
@@ -63,4 +63,9 @@ public static class StringExtensions
     {
         return WebUtility.UrlEncode(s).Replace('+', ' ');
     }
+
+    public static string AddBulletPoint(this string s)
+    {
+        return $"- {s}";
+    }
 }

--- a/src/Extensions/StringExtensions.cs
+++ b/src/Extensions/StringExtensions.cs
@@ -63,9 +63,4 @@ public static class StringExtensions
     {
         return WebUtility.UrlEncode(s).Replace('+', ' ');
     }
-
-    public static string AddBulletPoint(this string s)
-    {
-        return $"- {s}";
-    }
 }


### PR DESCRIPTION
In this PR, I have added StringBuilder extensions to avoid `.Append` reuse such as `.Append("- ").AppendLine()`

Closes #205 