### PR TITLE
Bump Remora.Commands to fix issue with optional slash command args

### DIFF
--- a/Octobot.csproj
+++ b/Octobot.csproj
@@ -25,6 +25,7 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+        <PackageReference Include="Remora.Commands" Version="10.0.5" />
         <PackageReference Include="Remora.Discord.Caching" Version="37.0.0" />
         <PackageReference Include="Remora.Discord.Extensions" Version="5.3.2" />
         <PackageReference Include="Remora.Discord.Hosting" Version="6.0.7" />


### PR DESCRIPTION
Fixes an exception that would occur when a slash command that has optional arguments would be called without them. See 
https://github.com/Remora/Remora.Discord/issues/319 for details
![image](https://github.com/LabsDevelopment/Octobot/assets/61277953/6589dee9-4bba-484e-9f77-b23dae514f45)
