### PR TITLE
/about: Use Octobot icon from CDN instead of Discord bot icon

### DIFF
--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -85,7 +85,7 @@ public class AboutCommandGroup : CommandGroup
         }
 
         var embed = new EmbedBuilder()
-            .WithAuthor(Messages.AboutBot, "https://cdn.mctaylors.ru/octobot-icon.png")
+            .WithAuthor(Messages.AboutBot, iconUrl: "https://cdn.mctaylors.ru/octobot-icon.png")
             .WithDescription(builder.ToString())
             .WithColour(ColorsList.Cyan)
             .WithImageUrl("https://cdn.mctaylors.ru/octobot-banner.png")


### PR DESCRIPTION
In this PR, I've changed the behavior of displaying the bot icon in /about. Now Octobot icon from [mctaylors' CDN](https://cdn.mctaylors.ru/octobot-icon.png) is displayed instead of icon of Discord bot from which Octobot code was run.

I also thought about displaying the name of the current Discord bot instead, but then there would be confusion with the developers in /about (e.g. the Discord bot is called "realest moderation bot", and something like "About realest moderation bot; Developers: ..." would be displayed).