### PR TITLE
/about: Add Octobot's description

### DIFF
--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -585,4 +585,7 @@
   <data name="ButtonReportIssue" xml:space="preserve">
       <value>Report an issue</value>
   </data>
+  <data name="AboutBotDescription" xml:space="preserve">
+      <value>Veemo! I'm a general-purpose bot for moderation (formerly known as Boyfriend) written by [Labs Development Team]({0}) in C# and Remora.Discord.</value>
+  </data>
 </root>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -585,4 +585,7 @@
   <data name="ButtonReportIssue" xml:space="preserve">
       <value>Сообщить о проблеме</value>
   </data>
+  <data name="AboutBotDescription" xml:space="preserve">
+      <value>Виимо! Я — бот общего назначения для модерации (ранее известный как Boyfriend), написанный [командой Labs Development]({0}) на C# и Remora.Discord.</value>
+  </data>
 </root>

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -585,4 +585,7 @@
   <data name="ButtonReportIssue" xml:space="preserve">
       <value>зарепортить баг</value>
   </data>
+  <data name="AboutBotDescription" xml:space="preserve">
+      <value>вииимо! звать меня Octobot (а в прошлом Boyfriend) и я бот который будет модерировать твой сервер. я написан [чуваками из Labs Development]({0}) на C# и Remora.Discord</value>
+  </data>
 </root>

--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -83,7 +83,8 @@ public class AboutCommandGroup : CommandGroup
 
     private async Task<Result> SendAboutBotAsync(IUser bot, Snowflake guildId, CancellationToken ct = default)
     {
-        var builder = new StringBuilder().Append("### ").AppendLine(Messages.AboutTitleDevelopers);
+        var builder = new StringBuilder().AppendLine(string.Format(Messages.AboutBotDescription, Octobot.OrganizationUrl))
+            .Append("### ").AppendLine(Messages.AboutTitleDevelopers);
         foreach (var dev in Developers)
         {
             var guildMemberResult = await _guildApi.GetGuildMemberAsync(

--- a/src/Messages.Designer.cs
+++ b/src/Messages.Designer.cs
@@ -1036,5 +1036,13 @@ namespace Octobot {
                 return ResourceManager.GetString("ButtonReportIssue", resourceCulture);
             }
         }
+
+        internal static string AboutBotDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("AboutBotDescription", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Octobot.cs
+++ b/src/Octobot.cs
@@ -27,7 +27,8 @@ public sealed class Octobot
     public static readonly AllowedMentions NoMentions = new(
         Array.Empty<MentionType>(), Array.Empty<Snowflake>(), Array.Empty<Snowflake>());
 
-    public const string RepositoryUrl = "https://github.com/LabsDevelopment/Octobot";
+    public const string OrganizationUrl = "https://github.com/LabsDevelopment";
+    public const string RepositoryUrl = $"{OrganizationUrl}/Octobot";
     public const string IssuesUrl = $"{RepositoryUrl}/issues";
 
     public static async Task Main(string[] args)


### PR DESCRIPTION
In this PR, I've added a description of Octobot to /about. Actually, /**about** is meant to have a description in it.