### PR TITLE
/about: Show link to GitHub profile if Discord member wasn't found

### DIFF
--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -90,7 +90,7 @@ public class AboutCommandGroup : CommandGroup
                 guildId, dev.Id, ct);
             var tag = guildMemberResult.IsSuccess
                 ? $"<@{dev.Id}>"
-                : MarkdownExtensions.Url($"@{dev.Username}", $"https://github.com/{dev.Username}");
+                : MarkdownExtensions.Hyperlink($"@{dev.Username}", $"https://github.com/{dev.Username}");
 
             builder.AppendBulletPointLine($"{tag} — {$"AboutDeveloper@{dev.Username}".Localized()}");
         }

--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -88,7 +88,9 @@ public class AboutCommandGroup : CommandGroup
         {
             var guildMemberResult = await _guildApi.GetGuildMemberAsync(
                 guildId, dev.Id, ct);
-            var tag = guildMemberResult.IsSuccess ? $"<@{dev.Id}>" : $"@{dev.Username}";
+            var tag = guildMemberResult.IsSuccess
+                ? $"<@{dev.Id}>"
+                : MarkdownExtensions.Url($"@{dev.Username}", $"https://github.com/{dev.Username}");
 
             builder.AppendBulletPointLine($"{tag} — {$"AboutDeveloper@{dev.Username}".Localized()}");
         }

--- a/src/Extensions/MarkdownExtensions.cs
+++ b/src/Extensions/MarkdownExtensions.cs
@@ -15,14 +15,14 @@ public static class MarkdownExtensions
     }
 
     /// <summary>
-    /// Formats a string to use Markdown URL formatting.
+    /// Formats a string to use Markdown Hyperlink formatting.
     /// </summary>
     /// <param name="text">The input text to format.</param>
     /// <param name="url">The URL to use in formatting.</param>
     /// <returns>
-    /// A markdown-formatted string with URL.
+    /// A markdown-formatted Hyperlink string.
     /// </returns>
-    public static string Url(string text, string url)
+    public static string Hyperlink(string text, string url)
     {
         return $"[{text}]({url})";
     }

--- a/src/Extensions/MarkdownExtensions.cs
+++ b/src/Extensions/MarkdownExtensions.cs
@@ -13,4 +13,17 @@ public static class MarkdownExtensions
     {
         return $"- {text}";
     }
+
+    /// <summary>
+    /// Formats a string to use Markdown URL formatting.
+    /// </summary>
+    /// <param name="text">The input text to format.</param>
+    /// <param name="url">The URL to use in formatting.</param>
+    /// <returns>
+    /// A markdown-formatted string with URL.
+    /// </returns>
+    public static string Url(string text, string url)
+    {
+        return $"[{text}]({url})";
+    }
 }


### PR DESCRIPTION
In this PR, the behavior of the developer list display in /about has been changed. Now, if a developer is not on the same server where the /about command was executed, their username will have a link to their GitHub profile.