### PR TITLE
/about: Show Discord bot username instead of hardcoded one

### DIFF
--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -400,7 +400,7 @@
     <value>Octobot's source code</value>
   </data>
   <data name="AboutBot" xml:space="preserve">
-    <value>About Octobot</value>
+      <value>About {0}</value>
   </data>
   <data name="AboutDeveloper@mctaylors" xml:space="preserve">
     <value>developer &amp; designer, Octobot's Wiki creator</value>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -400,7 +400,7 @@
     <value>Исходный код Octobot</value>
   </data>
   <data name="AboutBot" xml:space="preserve">
-    <value>Об Octobot</value>
+      <value>Об {0}</value>
   </data>
   <data name="AboutDeveloper@neroduckale" xml:space="preserve">
     <value>разработчик</value>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -400,7 +400,7 @@
     <value>Исходный код Octobot</value>
   </data>
   <data name="AboutBot" xml:space="preserve">
-      <value>Об {0}</value>
+      <value>О боте {0}</value>
   </data>
   <data name="AboutDeveloper@neroduckale" xml:space="preserve">
     <value>разработчик</value>

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -400,7 +400,7 @@
     <value>репа Octobot (тык)</value>
   </data>
   <data name="AboutBot" xml:space="preserve">
-    <value>немного об Octobot</value>
+      <value>немного об {0}</value>
   </data>
   <data name="AboutDeveloper@mctaylors" xml:space="preserve">
     <value>скучный девелопер + дизайнер создавший Octobot's Wiki</value>

--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -95,7 +95,8 @@ public class AboutCommandGroup : CommandGroup
             builder.AppendBulletPointLine($"{tag} — {$"AboutDeveloper@{dev.Username}".Localized()}");
         }
 
-        var embed = new EmbedBuilder().WithSmallTitle(Messages.AboutBot, bot)
+        var embed = new EmbedBuilder()
+            .WithSmallTitle(string.Format(Messages.AboutBot, bot.Username), bot)
             .WithDescription(builder.ToString())
             .WithColour(ColorsList.Cyan)
             .WithImageUrl("https://cdn.mctaylors.ru/octobot-banner.png")


### PR DESCRIPTION
In this PR, I made it so that in the Author field instead of the hardcoded name was the name of the Discord bot. This was done to match the icon next to it in the same field.

Replaces #224