### PR TITLE
Remove "extends IHostedService" from classes where it's not required

### DIFF
--- a/src/Commands/BanCommandGroup.cs
+++ b/src/Commands/BanCommandGroup.cs
@@ -33,12 +33,12 @@ public class BanCommandGroup : CommandGroup
     private readonly IDiscordRestGuildAPI _guildApi;
     private readonly GuildDataService _guildData;
     private readonly IDiscordRestUserAPI _userApi;
-    private readonly UtilityService _utility;
+    private readonly Utility _utility;
 
     public BanCommandGroup(
         ICommandContext context, IDiscordRestChannelAPI channelApi, GuildDataService guildData,
         IFeedbackService feedback, IDiscordRestGuildAPI guildApi, IDiscordRestUserAPI userApi,
-        UtilityService utility)
+        Utility utility)
     {
         _context = context;
         _channelApi = channelApi;

--- a/src/Commands/ClearCommandGroup.cs
+++ b/src/Commands/ClearCommandGroup.cs
@@ -30,11 +30,11 @@ public class ClearCommandGroup : CommandGroup
     private readonly IFeedbackService _feedback;
     private readonly GuildDataService _guildData;
     private readonly IDiscordRestUserAPI _userApi;
-    private readonly UtilityService _utility;
+    private readonly Utility _utility;
 
     public ClearCommandGroup(
         IDiscordRestChannelAPI channelApi, ICommandContext context, GuildDataService guildData,
-        IFeedbackService feedback, IDiscordRestUserAPI userApi, UtilityService utility)
+        IFeedbackService feedback, IDiscordRestUserAPI userApi, Utility utility)
     {
         _channelApi = channelApi;
         _context = context;

--- a/src/Commands/KickCommandGroup.cs
+++ b/src/Commands/KickCommandGroup.cs
@@ -30,12 +30,12 @@ public class KickCommandGroup : CommandGroup
     private readonly IDiscordRestGuildAPI _guildApi;
     private readonly GuildDataService _guildData;
     private readonly IDiscordRestUserAPI _userApi;
-    private readonly UtilityService _utility;
+    private readonly Utility _utility;
 
     public KickCommandGroup(
         ICommandContext context, IDiscordRestChannelAPI channelApi, GuildDataService guildData,
         IFeedbackService feedback, IDiscordRestGuildAPI guildApi, IDiscordRestUserAPI userApi,
-        UtilityService utility)
+        Utility utility)
     {
         _context = context;
         _channelApi = channelApi;

--- a/src/Commands/MuteCommandGroup.cs
+++ b/src/Commands/MuteCommandGroup.cs
@@ -32,11 +32,11 @@ public class MuteCommandGroup : CommandGroup
     private readonly IDiscordRestGuildAPI _guildApi;
     private readonly GuildDataService _guildData;
     private readonly IDiscordRestUserAPI _userApi;
-    private readonly UtilityService _utility;
+    private readonly Utility _utility;
 
     public MuteCommandGroup(
         ICommandContext context, GuildDataService guildData, IFeedbackService feedback,
-        IDiscordRestGuildAPI guildApi, IDiscordRestUserAPI userApi, UtilityService utility)
+        IDiscordRestGuildAPI guildApi, IDiscordRestUserAPI userApi, Utility utility)
     {
         _context = context;
         _guildData = guildData;

--- a/src/Commands/SettingsCommandGroup.cs
+++ b/src/Commands/SettingsCommandGroup.cs
@@ -57,11 +57,11 @@ public class SettingsCommandGroup : CommandGroup
     private readonly IFeedbackService _feedback;
     private readonly GuildDataService _guildData;
     private readonly IDiscordRestUserAPI _userApi;
-    private readonly UtilityService _utility;
+    private readonly Utility _utility;
 
     public SettingsCommandGroup(
         ICommandContext context, GuildDataService guildData,
-        IFeedbackService feedback, IDiscordRestUserAPI userApi, UtilityService utility)
+        IFeedbackService feedback, IDiscordRestUserAPI userApi, Utility utility)
     {
         _context = context;
         _guildData = guildData;

--- a/src/Octobot.cs
+++ b/src/Octobot.cs
@@ -87,7 +87,7 @@ public sealed class Octobot
                         .AddPostExecutionEvent<ErrorLoggingPostExecutionEvent>()
                         // Services
                         .AddSingleton<GuildDataService>()
-                        .AddSingleton<UtilityService>()
+                        .AddSingleton<Utility>()
                         .AddHostedService<MemberUpdateService>()
                         .AddHostedService<ScheduledEventUpdateService>()
                         .AddHostedService<SongUpdateService>()

--- a/src/Responders/GuildLoadedResponder.cs
+++ b/src/Responders/GuildLoadedResponder.cs
@@ -25,11 +25,11 @@ public class GuildLoadedResponder : IResponder<IGuildCreate>
     private readonly GuildDataService _guildData;
     private readonly ILogger<GuildLoadedResponder> _logger;
     private readonly IDiscordRestUserAPI _userApi;
-    private readonly UtilityService _utility;
+    private readonly Utility _utility;
 
     public GuildLoadedResponder(
         IDiscordRestChannelAPI channelApi, GuildDataService guildData, ILogger<GuildLoadedResponder> logger,
-        IDiscordRestUserAPI userApi, UtilityService utility)
+        IDiscordRestUserAPI userApi, Utility utility)
     {
         _channelApi = channelApi;
         _guildData = guildData;

--- a/src/Services/GuildDataService.cs
+++ b/src/Services/GuildDataService.cs
@@ -11,7 +11,7 @@ namespace Octobot.Services;
 /// <summary>
 ///     Handles saving, loading, initializing and providing <see cref="GuildData" />.
 /// </summary>
-public sealed class GuildDataService : IHostedService
+public sealed class GuildDataService
 {
     private readonly ConcurrentDictionary<Snowflake, GuildData> _datas = new();
     private readonly ILogger<GuildDataService> _logger;
@@ -22,16 +22,6 @@ public sealed class GuildDataService : IHostedService
     {
         _logger = logger;
         lifetime.ApplicationStopping.Register(ApplicationStopping);
-    }
-
-    public Task StartAsync(CancellationToken ct)
-    {
-        return Task.CompletedTask;
-    }
-
-    public Task StopAsync(CancellationToken ct)
-    {
-        return Task.CompletedTask;
     }
 
     private void ApplicationStopping()

--- a/src/Services/Update/MemberUpdateService.cs
+++ b/src/Services/Update/MemberUpdateService.cs
@@ -30,10 +30,10 @@ public sealed partial class MemberUpdateService : BackgroundService
     private readonly IDiscordRestGuildAPI _guildApi;
     private readonly GuildDataService _guildData;
     private readonly ILogger<MemberUpdateService> _logger;
-    private readonly UtilityService _utility;
+    private readonly Utility _utility;
 
     public MemberUpdateService(IDiscordRestChannelAPI channelApi, IDiscordRestGuildAPI guildApi,
-        GuildDataService guildData, ILogger<MemberUpdateService> logger, UtilityService utility)
+        GuildDataService guildData, ILogger<MemberUpdateService> logger, Utility utility)
     {
         _channelApi = channelApi;
         _guildApi = guildApi;

--- a/src/Services/Update/ScheduledEventUpdateService.cs
+++ b/src/Services/Update/ScheduledEventUpdateService.cs
@@ -19,10 +19,10 @@ public sealed class ScheduledEventUpdateService : BackgroundService
     private readonly IDiscordRestGuildScheduledEventAPI _eventApi;
     private readonly GuildDataService _guildData;
     private readonly ILogger<ScheduledEventUpdateService> _logger;
-    private readonly UtilityService _utility;
+    private readonly Utility _utility;
 
     public ScheduledEventUpdateService(IDiscordRestChannelAPI channelApi, IDiscordRestGuildScheduledEventAPI eventApi,
-        GuildDataService guildData, ILogger<ScheduledEventUpdateService> logger, UtilityService utility)
+        GuildDataService guildData, ILogger<ScheduledEventUpdateService> logger, Utility utility)
     {
         _channelApi = channelApi;
         _eventApi = eventApi;

--- a/src/Services/Utility.cs
+++ b/src/Services/Utility.cs
@@ -17,14 +17,14 @@ namespace Octobot.Services;
 ///     Provides utility methods that cannot be transformed to extension methods because they require usage
 ///     of some Discord APIs.
 /// </summary>
-public sealed class UtilityService : IHostedService
+public sealed class Utility
 {
     private readonly IDiscordRestChannelAPI _channelApi;
     private readonly IDiscordRestGuildScheduledEventAPI _eventApi;
     private readonly IDiscordRestGuildAPI _guildApi;
     private readonly IDiscordRestUserAPI _userApi;
 
-    public UtilityService(
+    public Utility(
         IDiscordRestChannelAPI channelApi, IDiscordRestGuildScheduledEventAPI eventApi, IDiscordRestGuildAPI guildApi,
         IDiscordRestUserAPI userApi)
     {
@@ -32,16 +32,6 @@ public sealed class UtilityService : IHostedService
         _eventApi = eventApi;
         _guildApi = guildApi;
         _userApi = userApi;
-    }
-
-    public Task StartAsync(CancellationToken ct)
-    {
-        return Task.CompletedTask;
-    }
-
-    public Task StopAsync(CancellationToken ct)
-    {
-        return Task.CompletedTask;
     }
 
     /// <summary>

--- a/src/Services/Utility.cs
+++ b/src/Services/Utility.cs
@@ -1,7 +1,6 @@
 using System.Drawing;
 using System.Text;
 using System.Text.Json.Nodes;
-using Microsoft.Extensions.Hosting;
 using Octobot.Data;
 using Octobot.Extensions;
 using Remora.Discord.API.Abstractions.Objects;


### PR DESCRIPTION
Originally, these classes were services because I thought that all DI-resolvable classes need to be services. However, this is not true, so we can make these classes (notably Utility and GuildDataService) not extend anything. `UtilityService` was renamed to `Utility` for simplicity