### PR TITLE
Use collection expressions in more places

### DIFF
--- a/src/Commands/AboutCommandGroup.cs
+++ b/src/Commands/AboutCommandGroup.cs
@@ -28,11 +28,11 @@ namespace Octobot.Commands;
 public class AboutCommandGroup : CommandGroup
 {
     private static readonly (string Username, Snowflake Id)[] Developers =
-    {
+    [
         ("Octol1ttle", new Snowflake(504343489664909322)),
         ("mctaylors", new Snowflake(326642240229474304)),
         ("neroduckale", new Snowflake(474943797063843851))
-    };
+    ];
 
     private readonly ICommandContext _context;
     private readonly IFeedbackService _feedback;

--- a/src/Commands/SettingsCommandGroup.cs
+++ b/src/Commands/SettingsCommandGroup.cs
@@ -36,7 +36,7 @@ public class SettingsCommandGroup : CommandGroup
     ///     that the orders match.
     /// </remarks>
     private static readonly IOption[] AllOptions =
-    {
+    [
         GuildSettings.Language,
         GuildSettings.WelcomeMessage,
         GuildSettings.ReceiveStartupMessages,
@@ -51,7 +51,7 @@ public class SettingsCommandGroup : CommandGroup
         GuildSettings.MuteRole,
         GuildSettings.EventNotificationRole,
         GuildSettings.EventEarlyNotificationOffset
-    };
+    ];
 
     private readonly ICommandContext _context;
     private readonly IFeedbackService _feedback;

--- a/src/Commands/ToolsCommandGroup.cs
+++ b/src/Commands/ToolsCommandGroup.cs
@@ -393,7 +393,7 @@ public class ToolsCommandGroup : CommandGroup
     }
 
     private static readonly TimestampStyle[] AllStyles =
-    {
+    [
         TimestampStyle.ShortDate,
         TimestampStyle.LongDate,
         TimestampStyle.ShortTime,
@@ -401,7 +401,7 @@ public class ToolsCommandGroup : CommandGroup
         TimestampStyle.ShortDateTime,
         TimestampStyle.LongDateTime,
         TimestampStyle.RelativeTime
-    };
+    ];
 
     /// <summary>
     ///     A slash command that shows the current timestamp with an optional offset in all styles supported by Discord.

--- a/src/Services/Update/MemberUpdateService.cs
+++ b/src/Services/Update/MemberUpdateService.cs
@@ -16,7 +16,7 @@ namespace Octobot.Services.Update;
 public sealed partial class MemberUpdateService : BackgroundService
 {
     private static readonly string[] GenericNicknames =
-    {
+    [
         "Albatross", "Alpha", "Anchor", "Banjo", "Bell", "Beta", "Blackbird", "Bulldog", "Canary",
         "Cat", "Calf", "Cyclone", "Daisy", "Dalmatian", "Dart", "Delta", "Diamond", "Donkey", "Duck",
         "Emu", "Eclipse", "Flamingo", "Flute", "Frog", "Goose", "Hatchet", "Heron", "Husky", "Hurricane",
@@ -24,7 +24,7 @@ public sealed partial class MemberUpdateService : BackgroundService
         "Nautilus", "Ostrich", "Octopus", "Pelican", "Puffin", "Pyramid", "Rattle", "Robin", "Rose",
         "Salmon", "Seal", "Shark", "Sheep", "Snake", "Sonar", "Stump", "Sparrow", "Toaster", "Toucan",
         "Torus", "Violet", "Vortex", "Vulture", "Wagon", "Whale", "Woodpecker", "Zebra", "Zigzag"
-    };
+    ];
 
     private readonly IDiscordRestChannelAPI _channelApi;
     private readonly IDiscordRestGuildAPI _guildApi;

--- a/src/Services/Update/SongUpdateService.cs
+++ b/src/Services/Update/SongUpdateService.cs
@@ -9,7 +9,7 @@ namespace Octobot.Services.Update;
 public sealed class SongUpdateService : BackgroundService
 {
     private static readonly (string Author, string Name, TimeSpan Duration)[] SongList =
-    {
+    [
         ("Yoko & the Gold Bazookas", "Rockagilly Blues", new TimeSpan(0, 2, 52)),
         ("Deep Cut", "Big Betrayal", new TimeSpan(0, 5, 55)),
         ("Squid Sisters", "Tomorrow's Nostalgia Today", new TimeSpan(0, 3, 7)),
@@ -30,7 +30,7 @@ public sealed class SongUpdateService : BackgroundService
         ("Turquoise October", "Octoling Rendezvous", new TimeSpan(0, 1, 57)),
         ("Damp Socks feat. Off the Hook", "Tentacle to the Metal", new TimeSpan(0, 2, 51)),
         ("Off the Hook", "Fly Octo Fly ~ Ebb & Flow (Octo)", new TimeSpan(0, 3, 5))
-    };
+    ];
 
     private readonly List<Activity> _activityList = [new Activity("with Remora.Discord", ActivityType.Game)];
 


### PR DESCRIPTION
ReSharper inspections have been updated, causing new warnings to appear in the codebase. This time, the "Use collection expressions" inspection has been enabled for usecases where the collection is not empty. This PR fixes the check failures caused by this inspection.