### PR TITLE
/userinfo: Show if the user was kicked w/ updates

### DIFF
--- a/locale/Messages.resx
+++ b/locale/Messages.resx
@@ -585,4 +585,7 @@
   <data name="ButtonReportIssue" xml:space="preserve">
       <value>Report an issue</value>
   </data>
+  <data name="UserInfoKicked" xml:space="preserve">
+      <value>Kicked</value>
+  </data>
 </root>

--- a/locale/Messages.ru.resx
+++ b/locale/Messages.ru.resx
@@ -585,4 +585,7 @@
   <data name="ButtonReportIssue" xml:space="preserve">
       <value>Сообщить о проблеме</value>
   </data>
+  <data name="UserInfoKicked" xml:space="preserve">
+      <value>Выгнан</value>
+  </data>
 </root>

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -585,4 +585,7 @@
   <data name="ButtonReportIssue" xml:space="preserve">
       <value>зарепортить баг</value>
   </data>
+  <data name="UserInfoKicked" xml:space="preserve">
+      <value>кикнут</value>
+  </data>
 </root>

--- a/locale/Messages.tt-ru.resx
+++ b/locale/Messages.tt-ru.resx
@@ -502,7 +502,7 @@
     <value>приколы полученные по заслугам</value>
   </data>
   <data name="UserInfoBannedPermanently" xml:space="preserve">
-    <value>забанен</value>
+    <value>пермабан</value>
   </data>
   <data name="UserInfoNotOnGuild" xml:space="preserve">
     <value>вышел из сервера</value>

--- a/src/Commands/KickCommandGroup.cs
+++ b/src/Commands/KickCommandGroup.cs
@@ -151,7 +151,9 @@ public class KickCommandGroup : CommandGroup
             return Result.FromError(kickResult.Error);
         }
 
-        data.GetOrCreateMemberData(target.ID).Roles.Clear();
+        var memberData = data.GetOrCreateMemberData(target.ID);
+        memberData.Roles.Clear();
+        memberData.Kicked = true;
 
         var title = string.Format(Messages.UserKicked, target.GetTag());
         var description = MarkdownExtensions.BulletPoint(string.Format(Messages.DescriptionActionReason, reason));

--- a/src/Commands/MuteCommandGroup.cs
+++ b/src/Commands/MuteCommandGroup.cs
@@ -300,9 +300,9 @@ public class MuteCommandGroup : CommandGroup
         }
 
         var memberData = data.GetOrCreateMemberData(target.ID);
-        var isMuted = memberData.MutedUntil is not null || communicationDisabledUntil is not null;
+        var wasMuted = memberData.MutedUntil is not null || communicationDisabledUntil is not null;
 
-        if (!isMuted)
+        if (!wasMuted)
         {
             var failedEmbed = new EmbedBuilder().WithSmallTitle(Messages.UserNotMuted, bot)
                 .WithColour(ColorsList.Red).Build();

--- a/src/Commands/ToolsCommandGroup.cs
+++ b/src/Commands/ToolsCommandGroup.cs
@@ -123,7 +123,7 @@ public class ToolsCommandGroup : CommandGroup
         }
 
         var wasMuted = (memberData.MutedUntil is not null && DateTimeOffset.UtcNow <= memberData.MutedUntil) ||
-                      communicationDisabledUntil is not null;
+                       communicationDisabledUntil is not null;
         var wasBanned = memberData.BannedUntil is not null;
         var wasKicked = memberData.Kicked;
 

--- a/src/Commands/ToolsCommandGroup.cs
+++ b/src/Commands/ToolsCommandGroup.cs
@@ -122,17 +122,17 @@ public class ToolsCommandGroup : CommandGroup
             embedColor = AppendGuildInformation(embedColor, guildMember, builder);
         }
 
-        var isMuted = (memberData.MutedUntil is not null && DateTimeOffset.UtcNow <= memberData.MutedUntil) ||
+        var wasMuted = (memberData.MutedUntil is not null && DateTimeOffset.UtcNow <= memberData.MutedUntil) ||
                       communicationDisabledUntil is not null;
         var wasBanned = memberData.BannedUntil is not null;
         var wasKicked = memberData.Kicked;
 
-        if (isMuted || wasBanned || wasKicked)
+        if (wasMuted || wasBanned || wasKicked)
         {
             builder.Append("### ")
                 .AppendLine(Markdown.Bold(Messages.UserInfoPunishments));
 
-            embedColor = AppendPunishmentsInformation(isMuted, wasKicked, wasBanned, memberData,
+            embedColor = AppendPunishmentsInformation(wasMuted, wasKicked, wasBanned, memberData,
                 builder, embedColor, communicationDisabledUntil);
         }
 
@@ -155,10 +155,10 @@ public class ToolsCommandGroup : CommandGroup
         return await _feedback.SendContextualEmbedResultAsync(embed, ct: ct);
     }
 
-    private static Color AppendPunishmentsInformation(bool isMuted, bool wasKicked, bool wasBanned,
+    private static Color AppendPunishmentsInformation(bool wasMuted, bool wasKicked, bool wasBanned,
         MemberData memberData, StringBuilder builder, Color embedColor, DateTimeOffset? communicationDisabledUntil)
     {
-        if (isMuted)
+        if (wasMuted)
         {
             AppendMuteInformation(memberData, communicationDisabledUntil, builder);
             embedColor = ColorsList.Red;

--- a/src/Commands/ToolsCommandGroup.cs
+++ b/src/Commands/ToolsCommandGroup.cs
@@ -136,7 +136,7 @@ public class ToolsCommandGroup : CommandGroup
                 builder, embedColor, communicationDisabledUntil);
         }
 
-        if (!guildMemberResult.IsSuccess || !wasBanned || !wasKicked)
+        if (!guildMemberResult.IsSuccess && !wasBanned)
         {
             builder.Append("### ")
                 .AppendLine(Markdown.Bold(Messages.UserInfoNotOnGuild));

--- a/src/Data/MemberData.cs
+++ b/src/Data/MemberData.cs
@@ -18,6 +18,7 @@ public sealed class MemberData
     public ulong Id { get; }
     public DateTimeOffset? BannedUntil { get; set; }
     public DateTimeOffset? MutedUntil { get; set; }
+    public bool Kicked { get; set; }
     public List<ulong> Roles { get; set; } = [];
     public List<Reminder> Reminders { get; } = [];
 }

--- a/src/Messages.Designer.cs
+++ b/src/Messages.Designer.cs
@@ -1036,5 +1036,13 @@ namespace Octobot {
                 return ResourceManager.GetString("ButtonReportIssue", resourceCulture);
             }
         }
+
+        internal static string UserInfoKicked
+        {
+            get
+            {
+                return ResourceManager.GetString("UserInfoKicked", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Responders/GuildMemberJoinedResponder.cs
+++ b/src/Responders/GuildMemberJoinedResponder.cs
@@ -43,6 +43,8 @@ public class GuildMemberJoinedResponder : IResponder<IGuildMemberAdd>
         var cfg = data.Settings;
         var memberData = data.GetOrCreateMemberData(user.ID);
 
+        memberData.Kicked = false;
+
         var returnRolesResult = await TryReturnRolesAsync(cfg, memberData, gatewayEvent.GuildID, user.ID, ct);
         if (!returnRolesResult.IsSuccess)
         {


### PR DESCRIPTION
Closes #241 

Updates:
- Show if the user was kicked by [adding "Kicked" parameter to MemberData](https://github.com/LabsDevelopment/Octobot/issues/241)
- Change `mctaylors-ru`'s `UserInfoBannedPermanently` string to be different from `UserInfoBanned`
- Finally add `AppendPunishmentsInformation` method to avoid Cognitive Complexity
- Use MemberData to check if the user was banned
- Rename variable `isMuted` to `wasMuted` to be consistent with other variable names