### PR TITLE
Ban usages of Thread#Sleep

### DIFF
--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -18,3 +18,5 @@ P:System.DateTime.Now;Use System.DateTime.UtcNow instead.
 P:System.DateTimeOffset.Now;Use System.DateTimeOffset.UtcNow instead.
 P:System.DateTimeOffset.DateTime;Use System.DateTimeOffset.UtcDateTime instead.
 M:System.IO.File.OpenWrite(System.String);File.OpenWrite(string) does not clear the file before writing to it. Use File.Create(string) instead.
+M:System.Threading.Thread.Sleep(System.Int32);Use Task.Delay(int, CancellationToken) instead.
+M:System.Threading.Thread.Sleep(System.TimeSpan);Use Task.Delay(TimeSpan, CancellationToken) instead.


### PR DESCRIPTION
Using Thread.Sleep blocks the _entire_ thread from doing *anything*, while Task.Delay allows the thread to execute other tasks while the delay is passing. The inability to cancel Thread.Sleep may also cause longer shutdowns

tl;dr Thread.Sleep bad, Task.Delay good
made because of https://github.com/LabsDevelopment/Octobot/pull/234/commits/578c03871de0dd042f2fe0918df296f0a8123e00