### PR TITLE
Fix newline in LogResult

### DIFF
--- a/src/Extensions/LoggerExtensions.cs
+++ b/src/Extensions/LoggerExtensions.cs
@@ -35,6 +35,7 @@ public static class LoggerExtensions
             return;
         }
 
-        logger.LogWarning("{UserMessage}\n{ResultErrorMessage}", message, result.Error.Message);
+        logger.LogWarning("{UserMessage}{NewLine}{ResultErrorMessage}", message, Environment.NewLine,
+            result.Error.Message);
     }
 }


### PR DESCRIPTION
Fixes an issue on Windows that would cause the `ResultErrorMessage` to be unindented.